### PR TITLE
Refactor resource_version_* actions parameters

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -134,8 +134,6 @@ def resource_version_create(context, data_dict):
 def resource_version_list(context, data_dict):
     """List versions of a given resource
 
-    :param package_id: the id the dataset
-    :type package_id: string
     :param resource_id: the id the resource
     :type resource_id: string
     :returns: list of matched versions
@@ -147,7 +145,8 @@ def resource_version_list(context, data_dict):
     if not resource:
         raise toolkit.ObjectNotFound('Resource not found')
 
-    toolkit.check_access('version_list', context, data_dict)
+    toolkit.check_access('version_list', context,
+                         {"package_id": resource.package_id})
 
     versions = model.Session.query(Version).\
         filter(Version.resource_id == resource.id).\
@@ -162,8 +161,6 @@ def resource_version_list(context, data_dict):
 def version_delete(context, data_dict):
     """Delete a specific version
 
-    :param package_id: the id the dataset
-    :type package_id: string
     :param version_id: the id of the version
     :type version_id: string
     :returns: The matched version
@@ -188,19 +185,19 @@ def version_delete(context, data_dict):
 def version_show(context, data_dict):
     """Show a specific version object
 
-    :param package_id: the id the dataset
-    :type package_id: string
     :param version_id: the id of the version
     :type version_id: string
     :returns: the version dictionary
     :rtype: dict
     """
-    toolkit.check_access('version_show', context, data_dict)
     model = context.get('model', core_model)
     version_id = toolkit.get_or_bust(data_dict, ['version_id'])
     version = model.Session.query(Version).get(version_id)
     if not version:
         raise toolkit.ObjectNotFound('Version not found')
+
+    toolkit.check_access('version_delete', context,
+                         {"package_id": version.package_id})
 
     return version.as_dict()
 
@@ -208,8 +205,6 @@ def version_show(context, data_dict):
 def resource_version_current(context, data_dict):
     ''' Show the current version for a resource
 
-    :param package_id: the id the dataset
-    :type package_id: string
     :param resource_id: the if of the resource
     :type resource_id: string
     :returns the version dictionary

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -71,7 +71,7 @@ def resource_version_create(context, data_dict):
     Currently you must have editor level access on the dataset
     to create a version.
 
-    :param package_id: the id of the dataset
+    :param package_id: the id or name of the dataset
     :type package_id: string
     :param resource_id: the id of the resource
     :type resource_id: string
@@ -87,10 +87,10 @@ def resource_version_create(context, data_dict):
 
     model = context.get('model', core_model)
 
-    package_id, resource_id, name = toolkit.get_or_bust(
+    package_id_or_name, resource_id, name = toolkit.get_or_bust(
         data_dict, ['package_id', 'resource_id', 'name'])
 
-    package = model.Package.get(package_id)
+    package = model.Package.get(package_id_or_name)
     if not package:
         raise toolkit.ObjectNotFound('Dataset not found')
 
@@ -100,12 +100,12 @@ def resource_version_create(context, data_dict):
 
     session = model.meta.create_local_session()
     activity = session.query(model.Activity). \
-        filter_by(object_id=data_dict['package_id']).\
+        filter_by(object_id=package.id). \
         order_by(model.Activity.timestamp.desc()).\
         first()
 
     version = Version(
-        package_id=data_dict['package_id'],
+        package_id=package.id,
         resource_id=data_dict['resource_id'],
         activity_id=activity.id,
         name=data_dict.get('name', None),

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -71,8 +71,6 @@ def resource_version_create(context, data_dict):
     Currently you must have editor level access on the dataset
     to create a version.
 
-    :param package_id: the id or name of the dataset
-    :type package_id: string
     :param resource_id: the id of the resource
     :type resource_id: string
     :param name: A short name for the version
@@ -87,12 +85,8 @@ def resource_version_create(context, data_dict):
 
     model = context.get('model', core_model)
 
-    package_id_or_name, resource_id, name = toolkit.get_or_bust(
-        data_dict, ['package_id', 'resource_id', 'name'])
-
-    package = model.Package.get(package_id_or_name)
-    if not package:
-        raise toolkit.ObjectNotFound('Dataset not found')
+    resource_id, name = toolkit.get_or_bust(
+        data_dict, ['resource_id', 'name'])
 
     resource = model.Resource.get(resource_id)
     if not resource:
@@ -100,12 +94,12 @@ def resource_version_create(context, data_dict):
 
     session = model.meta.create_local_session()
     activity = session.query(model.Activity). \
-        filter_by(object_id=package.id). \
+        filter_by(object_id=resource.package_id). \
         order_by(model.Activity.timestamp.desc()).\
         first()
 
     version = Version(
-        package_id=package.id,
+        package_id=resource.package_id,
         resource_id=data_dict['resource_id'],
         activity_id=activity.id,
         name=data_dict.get('name', None),

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -92,8 +92,7 @@ def resource_version_create(context, data_dict):
     if not resource:
         raise toolkit.ObjectNotFound('Resource not found')
 
-    session = model.meta.create_local_session()
-    activity = session.query(model.Activity). \
+    activity = model.Session.query(model.Activity). \
         filter_by(object_id=resource.package_id). \
         order_by(model.Activity.timestamp.desc()).\
         first()
@@ -107,13 +106,13 @@ def resource_version_create(context, data_dict):
         created=datetime.utcnow(),
         creator_user_id=context['auth_user_obj'].id)
 
-    session.add(version)
+    model.Session.add(version)
 
     try:
-        session.commit()
+        model.Session.commit()
     except IntegrityError as e:
         #  Name not unique, or foreign key constraint violated
-        session.rollback()
+        model.Session.rollback()
         log.debug("DB integrity error (version name not unique?): %s", e)
         raise toolkit.ValidationError(
             'Version names must be unique per resource'

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -19,28 +19,6 @@ class TestCreateResourceVersion(object):
 
         version = resource_version_create(
             get_context(user),{
-                'package_id': dataset['id'],
-                'resource_id': resource['id'],
-                'name': '1',
-                'notes': 'Version notes'
-            }
-        )
-
-        assert version
-        assert version['package_id'] == dataset['id']
-        assert version['resource_id'] == resource['id']
-        assert version['notes'] == 'Version notes'
-        assert version['name'] == '1'
-        assert version['creator_user_id'] == user['id']
-
-    def test_resource_version_create_using_name(self):
-        dataset = factories.Dataset()
-        resource = factories.Resource(package_id = dataset['id'])
-        user = factories.Sysadmin()
-
-        version = resource_version_create(
-            get_context(user),{
-                'package_id': dataset['name'],
                 'resource_id': resource['id'],
                 'name': '1',
                 'notes': 'Version notes'
@@ -61,7 +39,6 @@ class TestCreateResourceVersion(object):
 
         version = resource_version_create(
             get_context(user), {
-                'package_id': dataset['id'],
                 'resource_id': resource['id'],
                 'name': '1',
                 'notes': 'Version notes'
@@ -71,7 +48,6 @@ class TestCreateResourceVersion(object):
         with pytest.raises(toolkit.ValidationError):
             resource_version_create(
                 get_context(user), {
-                    'package_id': dataset['id'],
                     'resource_id': resource['id'],
                     'name': '1',
                     'notes': 'Version notes'
@@ -83,7 +59,6 @@ class TestCreateResourceVersion(object):
         with pytest.raises(toolkit.ObjectNotFound) as e:
             resource_version_create(
                 get_context(user), {
-                    'package_id': 'fake-dataset-id',
                     'resource_id': 'fake-resource-id',
                     'name': '1',
                     'notes': 'Version notes'
@@ -95,7 +70,6 @@ class TestCreateResourceVersion(object):
         with pytest.raises(toolkit.ObjectNotFound) as e:
             resource_version_create(
                 get_context(user), {
-                    'package_id': dataset['id'],
                     'resource_id': 'fake-resource-id',
                     'name': '1',
                     'notes': 'Version notes'
@@ -111,7 +85,6 @@ class TestCreateResourceVersion(object):
         with pytest.raises(toolkit.ValidationError):
             resource_version_create(
                 get_context(user), {
-                    'package_id': dataset['id'],
                     'resource_id': resource['id'],
                     'notes': 'Version notes'
                 }
@@ -128,7 +101,6 @@ class TestCreateResourceVersion(object):
 
         version = resource_version_create(
             context, {
-                'package_id': dataset['id'],
                 'resource_id': resource['id'],
                 'name': '1',
                 'notes': 'Version notes'
@@ -149,7 +121,6 @@ class TestCreateResourceVersion(object):
 
         version = resource_version_create(
             context, {
-                'package_id': dataset['id'],
                 'resource_id': resource['id'],
                 'name': '2'
             }
@@ -178,7 +149,6 @@ class TestResourceVersionList(object):
 
         resource_version_create(
             context, {
-                'package_id': dataset['id'],
                 'resource_id': resource['id'],
                 'name': '1'
             }
@@ -190,7 +160,6 @@ class TestResourceVersionList(object):
 
         resource_version_create(
             context, {
-                'package_id': dataset['id'],
                 'resource_id': resource['id'],
                 'name': '2',
                 'notes': 'Notes for version 2'
@@ -226,7 +195,6 @@ class TestResourceVersionList(object):
 
         resource_version_create(
             context, {
-                'package_id': dataset['id'],
                 'resource_id': resource['id'],
                 'name': '1'
             }
@@ -238,7 +206,6 @@ class TestResourceVersionList(object):
 
         resource_version_create(
             context, {
-                'package_id': dataset['id'],
                 'resource_id': resource['id'],
                 'name': '2',
                 'notes': 'Notes for version 2'
@@ -267,7 +234,6 @@ class TestVersionShow(object):
 
         version = resource_version_create(
             context, {
-                'package_id': dataset['id'],
                 'resource_id': resource['id'],
                 'name': '1',
                 'notes': 'Version notes'
@@ -295,7 +261,6 @@ class TestVersionDelete(object):
 
         version = resource_version_create(
             context, {
-                'package_id': dataset['id'],
                 'resource_id': resource['id'],
                 'name': '1',
                 'notes': 'Version notes'

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -33,6 +33,27 @@ class TestCreateResourceVersion(object):
         assert version['name'] == '1'
         assert version['creator_user_id'] == user['id']
 
+    def test_resource_version_create_using_name(self):
+        dataset = factories.Dataset()
+        resource = factories.Resource(package_id = dataset['id'])
+        user = factories.Sysadmin()
+
+        version = resource_version_create(
+            get_context(user),{
+                'package_id': dataset['name'],
+                'resource_id': resource['id'],
+                'name': '1',
+                'notes': 'Version notes'
+            }
+        )
+
+        assert version
+        assert version['package_id'] == dataset['id']
+        assert version['resource_id'] == resource['id']
+        assert version['notes'] == 'Version notes'
+        assert version['name'] == '1'
+        assert version['creator_user_id'] == user['id']
+
     def test_cannot_create_versions_with_same_name(self):
         dataset = factories.Dataset()
         resource = factories.Resource(package_id = dataset['id'])


### PR DESCRIPTION
`resource_version_*` actions shouldn't depend on the extra parameter `package_id` since all the data and logic that relates Package <-> Resource is already present in the Resource object.

So to simplify the API signature we are removing it. This way, creating a resource version only depends on the `resource_id`.