### PR TITLE
Render date in users timezone

### DIFF
--- a/ckanext/versions/logic/helpers.py
+++ b/ckanext/versions/logic/helpers.py
@@ -101,10 +101,3 @@ def get_license(license_id):
     '''
 
     return model.Package.get_license_register().get(license_id)
-
-def format_date(date):
-    '''
-    Format date to be e.g April 02, 2021 07:52PM
-    '''
-    return datetime.strptime(str(date), '%Y-%m-%d %H:%M:%S.%f').strftime("%B %d, %Y %I:%M%p%z")
-

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -77,7 +77,6 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'url_for_resource_version': helpers.url_for_resource_version,
             'dataset_version_has_link_resources': helpers.has_link_resources,
             'dataset_version_compare_pkg_dicts': helpers.compare_pkg_dicts,
-            'format_date': helpers.format_date,
         }
 
     # IUploader
@@ -144,7 +143,8 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             return {'name': 'versions_view',
                     'title': 'Versioning',
                     'icon': 'table',
-                    'default_title': plugins.toolkit._('Versioning'),}
+                    'default_title': plugins.toolkit._('Versioning'),
+                    'iframed': False}
 
     def can_view(self, data_dict):
         context = {'user': toolkit.c.user}

--- a/ckanext/versions/templates/versions_view.html
+++ b/ckanext/versions/templates/versions_view.html
@@ -51,7 +51,7 @@ integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQV
                 })();"></b>
             {% endif %}
             </td>
-            <td>{{ h.format_date(version.created) }}</td>
+            <td>{% snippet 'snippets/local_friendly_datetime.html', datetime_obj=version.created %}</td>
             <td>{{ h.linked_user(version.creator_user_id) }}</td>
           </tr>
       {% endfor %}


### PR DESCRIPTION
Let's use CKAN's core helper to render the timezone. This will keep consistency across other extensions since it is used to display dates in, for example, the [Additional Information table](https://github.com/ckan/ckan/blob/abfda8b401ec370c9c74fc67678dcb38f8c72a26/ckan/templates/package/snippets/additional_info.html#L64).