### PR TITLE
Feature: create-initial-version command

### DIFF
--- a/ckanext/versions/cli.py
+++ b/ckanext/versions/cli.py
@@ -12,6 +12,7 @@ from ckanext.versions.model import Version, create_tables, tables_exist
 def _log():
     return logging.getLogger(__name__)
 
+
 @click.group()
 def versions():
     '''versions commands
@@ -60,7 +61,9 @@ def create_initial_version(ctx, name, notes):
         click.secho('All resources contains at least one version.', fg="green")
         ctx.exit(1)
 
-    click.secho("Creating initial version for {} resources.".format(len(resources)))
+    click.secho(
+        "Creating initial version for {} resources.".format(len(resources))
+        )
     for resource in resources:
         _create_resource_initial_version(resource, name, notes)
     click.secho("Initial versions created succesfully.")

--- a/ckanext/versions/cli.py
+++ b/ckanext/versions/cli.py
@@ -1,9 +1,16 @@
 # encoding: utf-8
+import logging
 
 import click
+from ckan.model import Package, Resource, Session
+from ckan.plugins import toolkit
 
-from ckanext.versions.model import create_tables, tables_exist
+from ckanext.versions.logic import action
+from ckanext.versions.model import Version, create_tables, tables_exist
 
+
+def _log():
+    return logging.getLogger(__name__)
 
 @click.group()
 def versions():
@@ -36,6 +43,61 @@ def cleandb(ctx):
 
     create_tables()
     click.secho('Dataset versions tables created', fg="green")
+
+
+@versions.command()
+@click.pass_context
+@click.option('--name', default='1.0')
+@click.option('--notes', default='Initial version.')
+def create_initial_version(ctx, name, notes):
+    """Creates an initial resource version for all existing resources.
+
+    The creator of the version will be set as the package creator.
+    """
+    resources = _get_list_of_resources_without_version()
+
+    if not resources:
+        click.secho('All resources contains at least one version.', fg="green")
+        ctx.exit(1)
+
+    click.secho("Creating initial version for {} resources.".format(len(resources)))
+    for resource in resources:
+        _create_resource_initial_version(resource, name, notes)
+    click.secho("Initial versions created succesfully.")
+
+
+def _get_list_of_resources_without_version():
+    session = Session()
+    resources = session.query(Resource.id, Package.creator_user_id).\
+        filter(Resource.state != 'deleted').\
+        join(Package).\
+        order_by(Resource.created).\
+        all()
+
+    if not resources:
+        return None
+
+    versions = session.query(Version.resource_id).distinct()
+
+    resources_with_version = [v.resource_id for v in versions]
+
+    result = [r for r in resources if r.id not in resources_with_version]
+
+    return result
+
+
+def _create_resource_initial_version(resource, name, notes):
+    context = {'ignore_auth': True}
+    data_dict = {
+        'resource_id': resource.id,
+        'name': name,
+        'notes': notes,
+        'creator_user_id': resource.creator_user_id
+    }
+    try:
+        action.resource_version_create(context, data_dict)
+    except toolkit.ObjectNotFound:
+        _log().debug("Resource %s not found.", resource.id)
 
 
 def get_commands():

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -69,7 +69,8 @@ def resource_version_create(context, data_dict):
     """Create a new version from the current dataset's revision
 
     Currently you must have editor level access on the dataset
-    to create a version.
+    to create a version. If no creator_user_id is passed as a parameter, the
+    logged user is going to be set as the version creator.
 
     :param resource_id: the id of the resource
     :type resource_id: string
@@ -77,16 +78,21 @@ def resource_version_create(context, data_dict):
     :type name: string
     :param notes: A description for the version
     :type notes: string
+    :param creator_user_id: Optional. The id of the user creating the version.
+    :type creator_user_id: string
     :returns: the newly created version
     :rtype: dictionary
     """
     toolkit.check_access('version_create', context, data_dict)
-    assert context.get('auth_user_obj')  # Should be here after `check_access`
 
     model = context.get('model', core_model)
 
     resource_id, name = toolkit.get_or_bust(
         data_dict, ['resource_id', 'name'])
+
+    creator_user_id = data_dict.get('creator_user_id', None)
+    if not creator_user_id:
+        creator_user_id = context['auth_user_obj'].id
 
     resource = model.Resource.get(resource_id)
     if not resource:
@@ -104,7 +110,7 @@ def resource_version_create(context, data_dict):
         name=data_dict.get('name', None),
         notes=data_dict.get('notes', None),
         created=datetime.utcnow(),
-        creator_user_id=context['auth_user_obj'].id)
+        creator_user_id=creator_user_id)
 
     model.Session.add(version)
 

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -124,7 +124,11 @@ def resource_version_create(context, data_dict):
             'Version names must be unique per resource'
         )
 
-    log.info('Version "%s" created for resource %s', data_dict['name'], data_dict['resource_id'])
+    log.info(
+        'Version "%s" created for resource %s',
+        data_dict['name'],
+        data_dict['resource_id']
+        )
 
     return version.as_dict()
 

--- a/ckanext/versions/logic/auth.py
+++ b/ckanext/versions/logic/auth.py
@@ -27,7 +27,11 @@ def version_list(context, data_dict):
 
     This is permitted only to users who can view the dataset
     """
-    return is_authorized('package_show', context, {"id": data_dict['package_id']})
+    return is_authorized(
+        'package_show',
+        context,
+        {"id": data_dict['package_id']}
+        )
 
 
 @toolkit.auth_allow_anonymous_access
@@ -36,4 +40,8 @@ def version_show(context, data_dict):
 
     This is permitted only to users who can view the dataset
     """
-    return is_authorized('package_show', context, {"id": data_dict['package_id']})
+    return is_authorized(
+        'package_show',
+        context,
+        {"id": data_dict['package_id']}
+        )

--- a/ckanext/versions/logic/helpers.py
+++ b/ckanext/versions/logic/helpers.py
@@ -1,9 +1,9 @@
 from ckan import model
 from ckan.plugins import toolkit
-from datetime import datetime
 
 from ckanext.versions.lib.changes import (check_metadata_changes,
                                           check_resource_changes)
+
 
 def url_for_version(package, version=None, **kwargs):
     """Get the URL for a package / resource related action, with potential

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-import json
 import logging
 from datetime import datetime
 
@@ -138,19 +137,21 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             data_dict[UPLOAD_TS_FIELD] = current[UPLOAD_TS_FIELD]
         return data_dict
 
-    #IResourceView
+    # IResourceView
     def info(self):
-            return {'name': 'versions_view',
-                    'title': 'Versioning',
-                    'icon': 'table',
-                    'default_title': plugins.toolkit._('Versioning'),
-                    'iframed': False}
+        return {'name': 'versions_view',
+                'title': 'Versioning',
+                'icon': 'table',
+                'default_title': plugins.toolkit._('Versioning'),
+                'iframed': False}
 
     def can_view(self, data_dict):
         context = {'user': toolkit.c.user}
         resource = data_dict['resource']
         resource_id = resource.get('id')
-        version_list =  action.resource_version_list(context, {'resource_id': resource_id})
+        version_list = action.resource_version_list(
+            context, {'resource_id': resource_id}
+            )
 
         if not version_list:
             return False
@@ -159,7 +160,9 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def setup_template_variables(self, context, data_dict):
         resource = data_dict['resource']
         resource_id = resource.get('id')
-        version_list =  action.resource_version_list(context, {'resource_id': resource_id})
+        version_list = action.resource_version_list(
+            context, {'resource_id': resource_id}
+            )
 
         return {
             'versions': version_list,

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -1,8 +1,8 @@
 # encoding: utf-8
+import json
 import logging
 from datetime import datetime
 
-import json
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from ckan.lib.uploader import ALLOWED_UPLOAD_TYPES

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -14,11 +14,11 @@ class TestCreateResourceVersion(object):
 
     def test_resource_version_create(self):
         dataset = factories.Dataset()
-        resource = factories.Resource(package_id = dataset['id'])
+        resource = factories.Resource(package_id=dataset['id'])
         user = factories.Sysadmin()
 
         version = resource_version_create(
-            get_context(user),{
+            get_context(user), {
                 'resource_id': resource['id'],
                 'name': '1',
                 'notes': 'Version notes'
@@ -34,10 +34,10 @@ class TestCreateResourceVersion(object):
 
     def test_cannot_create_versions_with_same_name(self):
         dataset = factories.Dataset()
-        resource = factories.Resource(package_id = dataset['id'])
+        resource = factories.Resource(package_id=dataset['id'])
         user = factories.Sysadmin()
 
-        version = resource_version_create(
+        resource_version_create(
             get_context(user), {
                 'resource_id': resource['id'],
                 'name': '1',
@@ -66,7 +66,7 @@ class TestCreateResourceVersion(object):
             )
             assert e.msg == 'Dataset not found'
 
-        dataset = factories.Dataset()
+        factories.Dataset()
         with pytest.raises(toolkit.ObjectNotFound) as e:
             resource_version_create(
                 get_context(user), {
@@ -79,7 +79,7 @@ class TestCreateResourceVersion(object):
 
     def test_fails_if_not_name_provided(self):
         dataset = factories.Dataset()
-        resource = factories.Resource(package_id = dataset['id'])
+        resource = factories.Resource(package_id=dataset['id'])
         user = factories.Sysadmin()
 
         with pytest.raises(toolkit.ValidationError):
@@ -246,6 +246,7 @@ class TestVersionShow(object):
         assert result['name'] == '1'
         assert result['notes'] == 'Version notes'
         assert result['creator_user_id'] == user['id']
+
 
 @pytest.mark.usefixtures("clean_db", "versions_setup")
 class TestVersionDelete(object):


### PR DESCRIPTION
Some implementations may require an initial resource version to be created for all the existing resources. This first draft implements a command to create it.

### Some discussion
- What's the best approach to get a list of all the resources in the system?
- Define how to set the `creator_user_id` properly. The action logic is to set the authenticated user as the creator of the version, but if we are running a migration script, who should be the creator? The package creator? I tried to implement a new parameter but it opens a new set of difficulties (and maybe an over engineered logic in the action?):
  - Check if the user still exist
  - Check if the user has still access to the dataset
  - If the user provided do not meet criteria, we just log the error or set any sysadmin by default?
- Is this something to be implemented here, or should be a dedicated script in each custom implementation? 

PS: sorry about the pep8 commit messing with the diff.