### PR TITLE
Refactor so versions_view is not iframed

### DIFF
--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -143,7 +143,7 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             return {'name': 'versions_view',
                     'title': 'Versioning',
                     'icon': 'table',
-                    'default_title': plugins.toolkit._('Versioning'),
+                    'default_title': plugins.toolkit._('Version history'),
                     'iframed': False}
 
     def can_view(self, data_dict):

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -141,7 +141,7 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     #IResourceView
     def info(self):
             return {'name': 'versions_view',
-                    'title': 'Versioning',
+                    'title': 'Version history',
                     'icon': 'table',
                     'default_title': plugins.toolkit._('Version history'),
                     'iframed': False}

--- a/ckanext/versions/templates/versions_view.html
+++ b/ckanext/versions/templates/versions_view.html
@@ -1,14 +1,3 @@
-
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
-integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
-integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
-
-{# start test versioning #}
-<div class="module-content">
   <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
     <thead>
       <tr>
@@ -29,7 +18,7 @@ integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQV
               {% endif %}
             </td>
             <td style="text-align: center;">{{ version.name }}</td>
-            <td><a target="_top" href="{{h.url_for('resource.read', id=version.package_id, resource_id=version.resource_id, activity_id=version.activity_id)}}">{{ resource.name }}</a></td>
+            <td><a href="{{h.url_for('resource.read', id=version.package_id, resource_id=version.resource_id, activity_id=version.activity_id)}}">{{ resource.name }}</a></td>
             <td id="td-{{loop.index}}"><span id="foo-{{loop.index}}" style="white-space: nowrap;
               display: inline-block;
               overflow: hidden;
@@ -56,5 +45,3 @@ integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQV
           </tr>
       {% endfor %}
   </table>
-</div>
-{# end test versioning #}


### PR DESCRIPTION
Having an iframed view causes some issues:
- It's not easy to import base css styles
- Links that redirects reloads the iframe instead of redirecting the top page. (Even when we can fix it by adding `target="_top"` in a link, we cannot easily fix it for CKAN helpers like `h.linked_user(...)`

As an MVP approach we set this view as `iframed: False` and lets render the view directly in the main html.