### PR TITLE
Set exit status to 0

### DIFF
--- a/ckanext/versions/cli.py
+++ b/ckanext/versions/cli.py
@@ -19,7 +19,7 @@ def initdb(ctx):
     """
     if tables_exist():
         click.secho('Dataset versions tables already exist', fg="green")
-        ctx.exit(1)
+        ctx.exit(0)
 
     create_tables()
     click.secho('Dataset versions tables created', fg="green")
@@ -32,7 +32,7 @@ def cleandb(ctx):
     """
     if tables_exist():
         click.secho('Dataset versions tables already exist', fg="green")
-        ctx.exit(1)
+        ctx.exit(0)
 
     create_tables()
     click.secho('Dataset versions tables created', fg="green")


### PR DESCRIPTION
Exit status 1 may cause issues when integrating in pipelines and other scripts. Setting it to zero.