### PR TITLE
Fix authentication logic in resource_version_create

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -80,9 +80,6 @@ def resource_version_create(context, data_dict):
     :returns: the newly created version
     :rtype: dictionary
     """
-    toolkit.check_access('version_create', context, data_dict)
-    assert context.get('auth_user_obj')  # Should be here after `check_access`
-
     model = context.get('model', core_model)
 
     resource_id, name = toolkit.get_or_bust(
@@ -91,6 +88,10 @@ def resource_version_create(context, data_dict):
     resource = model.Resource.get(resource_id)
     if not resource:
         raise toolkit.ObjectNotFound('Resource not found')
+
+    toolkit.check_access('version_create', context,
+                         {"package_id": resource.package_id})
+    assert context.get('auth_user_obj')  # Should be here after `check_access`
 
     activity = model.Session.query(model.Activity). \
         filter_by(object_id=resource.package_id). \

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -32,6 +32,29 @@ class TestCreateResourceVersion(object):
         assert version['name'] == '1'
         assert version['creator_user_id'] == user['id']
 
+    def test_resource_version_create_editor_user(self):
+        user = factories.User()
+        owner_org = factories.Organization(
+            users=[{'name': user['name'], 'capacity': 'editor'}]
+        )
+        dataset = factories.Dataset(owner_org=owner_org['id'])
+        resource = factories.Resource(package_id = dataset['id'])
+
+        version = resource_version_create(
+            get_context(user),{
+                'resource_id': resource['id'],
+                'name': '1',
+                'notes': 'Version notes'
+            }
+        )
+
+        assert version
+        assert version['package_id'] == dataset['id']
+        assert version['resource_id'] == resource['id']
+        assert version['notes'] == 'Version notes'
+        assert version['name'] == '1'
+        assert version['creator_user_id'] == user['id']
+
     def test_cannot_create_versions_with_same_name(self):
         dataset = factories.Dataset()
         resource = factories.Resource(package_id = dataset['id'])


### PR DESCRIPTION
`version_create` requires a `package_id` parameter. 

This method was working because testing was always beinh done with sysadmin users so I added an extra test to create a version with an editor member.