### PR TITLE
Fix resource name in versions_view.html

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -260,7 +260,7 @@ def activity_resource_show(context, data_dict):
         )
 
     package = toolkit.get_action('activity_data_show')(
-                {'model': core_model},
+                {'model': core_model, 'user': context['user']},
                 {'id': activity_id, 'object_type': 'package'}
                 )
     old_resource = None

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -233,7 +233,9 @@ def resource_history(context, data_dict):
 
     result = []
     for version in versions_list:
-            resource = activity_resource_show({},
+            resource = activity_resource_show({
+                'user': context['user']
+            },
             {
                 'activity_id': version['activity_id'],
                 'resource_id': version['resource_id']

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -85,13 +85,11 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         context = {'user': toolkit.c.user}
         resource = data_dict['resource']
         resource_id = resource.get('id')
-        version_list = action.resource_version_list(context, {
+        resource_history = action.resource_history(context, {
             'resource_id': resource_id}
             )
-
         return {
-            'versions': version_list,
-            'resource': resource
+            'resource_history': resource_history
             }
 
     def view_template(self, context, data_dict):

--- a/ckanext/versions/templates/versions_view.html
+++ b/ckanext/versions/templates/versions_view.html
@@ -10,23 +10,23 @@
       </tr>
     </thead>
     <tbody>
-      {% for version in versions %}
+      {% for resource in resource_history %}
           <tr role="row">
             <td style="text-align: center;">
-              {% if version.current_version %}
+              {% if resource.version.current_version %}
                 <i class="fa fa-check"></i>
               {% endif %}
             </td>
-            <td style="text-align: center;">{{ version.name }}</td>
-            <td><a href="{{h.url_for('resource.read', id=version.package_id, resource_id=version.resource_id, activity_id=version.activity_id)}}">{{ resource.name }}</a></td>
+            <td style="text-align: center;">{{ resource.version.name }}</td>
+            <td><a href="{{h.url_for('resource.read', id=resource.package_id, resource_id=resource.id, activity_id=resource.version.activity_id)}}">{{ resource.name }}</a></td>
             <td id="td-{{loop.index}}"><span id="foo-{{loop.index}}" style="white-space: nowrap;
               display: inline-block;
               overflow: hidden;
               text-overflow: ellipsis;
               width: 80%;
               color: #222;"
-              >{{ version.notes }}</span>
-              {% if version.notes|length > 26 %}
+              >{{ resource.version.notes }}</span>
+              {% if resource.version.notes|length > 26 %}
                 <b
                 class="caret"
                 style="color: #4885A7; position: absolute; margin-left: 20px; margin-top: 8px; cursor: pointer;"
@@ -40,8 +40,8 @@
                 })();"></b>
             {% endif %}
             </td>
-            <td>{% snippet 'snippets/local_friendly_datetime.html', datetime_obj=version.created %}</td>
-            <td>{{ h.linked_user(version.creator_user_id) }}</td>
+            <td>{% snippet 'snippets/local_friendly_datetime.html', datetime_obj=resource.version.created %}</td>
+            <td>{{ h.linked_user(resource.version.creator_user_id) }}</td>
           </tr>
       {% endfor %}
   </table>


### PR DESCRIPTION
We are currently showing the name of the last file uploaded even if the file changed it's name across versions. This PR gets the details of the resource for all the previous versions and prints the correct name.