### PR TITLE
Reorder template folder

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -194,7 +194,7 @@ def version_show(context, data_dict):
     if not version:
         raise toolkit.ObjectNotFound('Version not found')
 
-    toolkit.check_access('version_delete', context,
+    toolkit.check_access('version_show', context,
                          {"package_id": version.package_id})
 
     return version.as_dict()

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -93,7 +93,7 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             }
 
     def view_template(self, context, data_dict):
-        return 'versions_view.html'
+        return 'versions/versions_view.html'
 
     def form_template(self, context, data_dict):
         return False

--- a/ckanext/versions/templates/versions/versions_view.html
+++ b/ckanext/versions/templates/versions/versions_view.html
@@ -26,7 +26,7 @@
               width: 80%;
               color: #222;"
               >{{ resource.version.notes }}</span>
-              {% if resource.version.notes and resource.version.notes|length > 26 %}
+              {% if resource.version.notes|length > 26 %}
                 <b
                 class="caret"
                 style="color: #4885A7; position: absolute; margin-left: 20px; margin-top: 8px; cursor: pointer;"

--- a/ckanext/versions/templates/versions/versions_view.html
+++ b/ckanext/versions/templates/versions/versions_view.html
@@ -26,7 +26,7 @@
               width: 80%;
               color: #222;"
               >{{ resource.version.notes }}</span>
-              {% if resource.version.notes|length > 26 %}
+              {% if resource.version.notes and resource.version.notes|length > 26 %}
                 <b
                 class="caret"
                 style="color: #4885A7; position: absolute; margin-left: 20px; margin-top: 8px; cursor: pointer;"


### PR DESCRIPTION
This PR moves the `versions_view.html` template into the `versions` folder for better modularity.

Also fixed an issue in the `check_access` method of `version_show`.