### PR TITLE
Feature/reorder versioning view

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -341,3 +341,17 @@ def _generate_diff(obj1, obj2, diff_type):
 
     return diff
 
+@toolkit.chained_action
+def resource_view_list(up_func, context, data_dict):
+    ''' Overrides core action to always return versions_view as the last view.
+    '''
+    resource_views = up_func(context, data_dict)
+
+    versions_views = []
+    for i, view in enumerate(resource_views):
+        if view['view_type'] == 'versions_view':
+            versions_views.append(resource_views.pop(i))
+
+    resource_views.extend(versions_views)
+
+    return resource_views

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -344,6 +344,9 @@ def _generate_diff(obj1, obj2, diff_type):
 @toolkit.chained_action
 def resource_view_list(up_func, context, data_dict):
     ''' Overrides core action to always return versions_view as the last view.
+
+    Note: This will override the default order field for all the
+    versions_view since it will force them to be displayed at the end.
     '''
     resource_views = up_func(context, data_dict)
 

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -47,7 +47,8 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'resource_version_list': action.resource_version_list,
             'resource_version_current': action.resource_version_current,
             'version_show': action.version_show,
-            'version_delete': action.version_delete
+            'version_delete': action.version_delete,
+            'resource_view_list': action.resource_view_list,
         }
 
     # IAuthFunctions

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -1,6 +1,6 @@
 import pytest
 from ckan.plugins import toolkit
-from ckan.tests import factories
+from ckan.tests import factories, helpers
 
 from ckanext.versions.logic.action import (activity_resource_show,
                                            resource_version_create,
@@ -10,7 +10,7 @@ from ckanext.versions.logic.action import (activity_resource_show,
 from ckanext.versions.tests import get_context
 
 
-@pytest.mark.usefixtures("clean_db", "versions_setup")
+@pytest.mark.usefixtures('clean_db', 'versions_setup')
 class TestCreateResourceVersion(object):
 
     def test_resource_version_create(self):
@@ -159,7 +159,7 @@ class TestCreateResourceVersion(object):
         assert activity_resource['name'] == 'Second Name'
 
 
-@pytest.mark.usefixtures("clean_db", "versions_setup")
+@pytest.mark.usefixtures('clean_db', 'versions_setup')
 class TestResourceVersionList(object):
 
     def test_resource_version_list(self):
@@ -244,7 +244,7 @@ class TestResourceVersionList(object):
         assert current_version['notes'] == 'Notes for version 2'
 
 
-@pytest.mark.usefixtures("clean_db", "versions_setup")
+@pytest.mark.usefixtures('clean_db', 'versions_setup')
 class TestVersionShow(object):
 
     def test_version_show(self):
@@ -272,7 +272,7 @@ class TestVersionShow(object):
         assert result['creator_user_id'] == user['id']
 
 
-@pytest.mark.usefixtures("clean_db", "versions_setup")
+@pytest.mark.usefixtures('clean_db', 'versions_setup')
 class TestVersionDelete(object):
 
     def test_version_delete(self):
@@ -300,7 +300,7 @@ class TestVersionDelete(object):
             version_show(context, {'version_id': version['id']})
 
 
-@pytest.mark.usefixtures("clean_db", "versions_setup")
+@pytest.mark.usefixtures('clean_db', 'versions_setup')
 class TestActivityActions(object):
 
     def test_activity_resource_shows_correct_resource(self):
@@ -355,3 +355,65 @@ class TestActivityActions(object):
 
         assert activity_resource_2
         assert activity_resource_2['name'] == 'Second name'
+
+@pytest.mark.usefixtures('clean_db', 'versions_setup')
+class TestResourceView(object):
+    def test_resource_view_list_returns_versions_view_last(self):
+        user = factories.Sysadmin()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org = org['id'])
+        resource = factories.Resource(
+            package_id=dataset['id']
+        )
+        image_view_dict = {
+            'resource_id': resource['id'],
+            'view_type': 'image_view',
+            'title': 'Image View',
+            'description': 'A nice image view',
+            'image_url': 'url',
+        }
+
+        versions_view_dict = {
+            'resource_id': resource['id'],
+            'view_type': 'versions_view',
+            'title': 'Versions View',
+            'description': 'A nice versions view',
+        }
+
+        versions_view = helpers.call_action('resource_view_create',**versions_view_dict)
+        image_view = helpers.call_action('resource_view_create', **image_view_dict)
+
+        resource_views = helpers.call_action('resource_view_list', id=resource['id'])
+
+        assert resource_views[0]['id'] == image_view['id']
+        assert resource_views[1]['id'] == versions_view['id']
+
+    def test_resource_view_list_returns_versions_view_last(self):
+        user = factories.Sysadmin()
+        org = factories.Organization()
+        dataset = factories.Dataset(owner_org = org['id'])
+        resource = factories.Resource(
+            package_id=dataset['id']
+        )
+        image_view_dict = {
+            'resource_id': resource['id'],
+            'view_type': 'image_view',
+            'title': 'Image View',
+            'description': 'A nice image view',
+            'image_url': 'url',
+        }
+
+        image_view_dict_2 = {
+            'resource_id': resource['id'],
+            'view_type': 'image_view',
+            'title': 'Image View 2',
+            'image_url': 'url',
+        }
+
+        image_view = helpers.call_action('resource_view_create',**image_view_dict)
+        image_view_2 = helpers.call_action('resource_view_create', **image_view_dict_2)
+
+        resource_views = helpers.call_action('resource_view_list', id=resource['id'])
+
+        assert resource_views[0]['id'] == image_view['id']
+        assert resource_views[1]['id'] == image_view_2['id']

--- a/test.ini
+++ b/test.ini
@@ -14,8 +14,7 @@ use = config:../ckan/test-core.ini
 # Insert any custom config settings to be used when running your extension's
 # tests here.
 
-ckan.plugins = versions
-
+ckan.plugins = versions image_view
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
Is desired as requirement for the Versions View to be always displayed as the last view. When creating a resource some views can have a delay to be created (eg: it can depend on xloader to be finished.) and cause `versions_view` to be displayed as the first view.

This PR will always display versions_view as the last one.