### PR TITLE
Implement download blueprint for versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,117 @@ Internally, this extension will use CKAN's 2.9 activities to preserve
 old revisions of metadata, and ensure uploaded data resources are unique
 and do not replace or override each other as resources are modified.
 
-Although the extension has it's own Uploader this extensions it is designed to be
-used with `ckanext-blob-storage <https://github.com/datopian/ckanext-blob-storage>`_
+This extension is designed to be used with
+`ckanext-blob-storage <https://github.com/datopian/ckanext-blob-storage>`_
 
 As interface, this extension exposes a few new API actions described below. (no
 UI work yet)
+
+------------
+API Endpoints
+------------
+
+resource_version_create:
+
+    curl -X POST -H "Authorization: $API_KEY" \
+                    -H "Content-Type: application/json;charset=utf-8"
+                    -d '{"resource_id": "9509ca60-a113-4d3b-8afa-83172b87368a", "name":"v1.0", "notes": "First Version."}'
+                    -k "http://ckan:5000/api/action/resource_version_create"
+    {
+    "help": "http://ckan:5000/api/3/action/help_show?name=resource_version_create",
+    "success": true,
+    "result": {
+        "id": "7eab640a-546a-4be1-97bf-9c7aa7a543ed",
+        "package_id": "9a2ca5e4-1018-479d-8365-9e2f54c69d26",
+        "resource_id": "9509ca60-a113-4d3b-8afa-83172b87368a",
+        "activity_id": "2efbf349-5c66-4d4a-8c22-8dc31db7453a",
+        "name": "v1.0",
+        "notes": "First Version.",
+        "creator_user_id": "62f05721-fb2f-453f-9816-702f9c9f76c6",
+        "created": "2021-05-15 21:01:30.980231"
+        }
+    }
+
+resource_version_list:
+
+    curl -X POST -H "Authorization: $API_KEY"
+                 -H "Content-Type: application/json;charset=utf-8"
+                 -d '{"resource_id": "9509ca60-a113-4d3b-8afa-83172b87368a"}'
+                 -k "http://ckan:5000/api/action/resource_version_list"
+    {
+    "help": "http://ckan:5000/api/3/action/help_show?name=resource_version_list",
+    "success": true,
+    "result": [
+        {
+        "id": "49a30927-d072-46c5-9602-f6388dfaf9c1",
+        "package_id": "9a2ca5e4-1018-479d-8365-9e2f54c69d26",
+        "resource_id": "9509ca60-a113-4d3b-8afa-83172b87368a",
+        "activity_id": "2efbf349-5c66-4d4a-8c22-8dc31db7453a",
+        "name": "v2.0",
+        "notes": "Second Version.",
+        "creator_user_id": "62f05721-fb2f-453f-9816-702f9c9f76c6",
+        "created": "2021-05-15 21:10:57.069277"
+        },
+        {
+        "id": "7eab640a-546a-4be1-97bf-9c7aa7a543ed",
+        "package_id": "9a2ca5e4-1018-479d-8365-9e2f54c69d26",
+        "resource_id": "9509ca60-a113-4d3b-8afa-83172b87368a",
+        "activity_id": "2efbf349-5c66-4d4a-8c22-8dc31db7453a",
+        "name": "v1.0",
+        "notes": "First Version.",
+        "creator_user_id": "62f05721-fb2f-453f-9816-702f9c9f76c6",
+        "created": "2021-05-15 21:01:30.980231"
+        }
+      ]
+    }
+
+version_show:
+
+    curl -X POST -H "Authorization: $API_KEY"
+                 -H "Content-Type: application/json;charset=utf-8"
+                 -d '{"version_id": "7eab640a-546a-4be1-97bf-9c7aa7a543ed"}'
+                 -k "http://ckan:5000/api/action/version_show"
+    {
+    "help": "http://ckan:5000/api/3/action/help_show?name=version_show",
+    "success": true,
+    "result": {
+        "id": "7eab640a-546a-4be1-97bf-9c7aa7a543ed",
+        "package_id": "9a2ca5e4-1018-479d-8365-9e2f54c69d26",
+        "resource_id": "9509ca60-a113-4d3b-8afa-83172b87368a",
+        "activity_id": "2efbf349-5c66-4d4a-8c22-8dc31db7453a",
+        "name": "v1.0",
+        "notes": "First Version.",
+        "creator_user_id": "62f05721-fb2f-453f-9816-702f9c9f76c6",
+        "created": "2021-05-15 21:01:30.980231"
+      }
+    }
+
+version_delete:
+
+    curl -X POST -H "Authorization: $API_KEY"
+                 -H "Content-Type: application/json;charset=utf-8"
+                 -d '{"version_id": "7eab640a-546a-4be1-97bf-9c7aa7a543ed"}'
+                 -k "http://ckan:5000/api/action/version_delete"
+    {
+    "help": "http://ckan:5000/api/3/action/help_show?name=version_delete",
+    "success": true,
+    "result": null
+    }
+
+
+------------
+Download Endpoint
+------------
+
+`/dataset/<dataset_id>/resource/<resource_id>/v/<version_name>/download/`
+
+This extension also has a specific endpoint to download the file in previous
+versions (only if the storage layer supports it). Internally it redirects to core
+CKAN download endpoint with an extra query parameter for the activity_id.
+
+Currently it works when using with `ckanext-blob-storage <https://github.com/datopian/ckanext-blob-storage>`_
+but any other storage layer with support for activity_id can be used as well.
+
 
 ------------
 Requirements

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ Download Endpoint
 
 To download the file for a specific version::
 
-    /dataset/<dataset_id>/resource/<resource_id>/v/<version_name>/download/
+    /dataset/<dataset_id>/resource/<resource_id>/vervsion/<version_id>/download/
 
 This extension also has a specific endpoint to download the file in previous
 versions (only if the storage layer supports it). Internally it redirects to core

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,9 @@ version_delete::
 Download Endpoint
 ------------
 
-`/dataset/<dataset_id>/resource/<resource_id>/v/<version_name>/download/`
+To download the file for a specific version::
+
+    /dataset/<dataset_id>/resource/<resource_id>/v/<version_name>/download/
 
 This extension also has a specific endpoint to download the file in previous
 versions (only if the storage layer supports it). Internally it redirects to core

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ UI work yet)
 API Endpoints
 ------------
 
-resource_version_create:
+resource_version_create::
 
     curl -X POST -H "Authorization: $API_KEY" \
                     -H "Content-Type: application/json;charset=utf-8"
@@ -40,7 +40,7 @@ resource_version_create:
         }
     }
 
-resource_version_list:
+resource_version_list::
 
     curl -X POST -H "Authorization: $API_KEY"
                  -H "Content-Type: application/json;charset=utf-8"
@@ -73,7 +73,7 @@ resource_version_list:
       ]
     }
 
-version_show:
+version_show::
 
     curl -X POST -H "Authorization: $API_KEY"
                  -H "Content-Type: application/json;charset=utf-8"
@@ -94,7 +94,7 @@ version_show:
       }
     }
 
-version_delete:
+version_delete::
 
     curl -X POST -H "Authorization: $API_KEY"
                  -H "Content-Type: application/json;charset=utf-8"

--- a/ckanext/versions/blueprints.py
+++ b/ckanext/versions/blueprints.py
@@ -40,6 +40,6 @@ def version_download(id, resource_id, version):
 
 
 blueprint.add_url_rule(
-    u'/dataset/<id>/resource/<resource_id>/v/<version>/download',
+    u'/dataset/<id>/resource/<resource_id>/version/<version>/download',
     view_func=version_download
     )

--- a/ckanext/versions/blueprints.py
+++ b/ckanext/versions/blueprints.py
@@ -10,8 +10,8 @@ blueprint = Blueprint(
 )
 
 
-def version_download(id, resource_id, version):
-    """Download resource blueprint supporting version name.
+def version_download(id, resource_id, version_id):
+    """Download resource blueprint supporting version id.
 
     This download blueprint gets the activity_id from the version and redirects
     to a download url that can handle it. Currently is working with
@@ -24,10 +24,12 @@ def version_download(id, resource_id, version):
     }
 
     try:
-        activity_id = action.get_activity_id_from_resource_version_name(
-            context, {'resource_id': resource_id, 'version_name': version})
+        version = action.version_show(
+            context, {'resource_id': resource_id, 'version_id': version_id}
+            )
+        activity_id = version['activity_id']
     except toolkit.NotFound:
-        toolkit.abort(404, toolkit._(u'Activity not found'))
+        toolkit.abort(404, toolkit._(u'Version not found'))
 
     download_url = toolkit.url_for(
         'resource.download',
@@ -40,6 +42,6 @@ def version_download(id, resource_id, version):
 
 
 blueprint.add_url_rule(
-    u'/dataset/<id>/resource/<resource_id>/version/<version>/download',
+    u'/dataset/<id>/resource/<resource_id>/version/<version_id>/download',
     view_func=version_download
     )

--- a/ckanext/versions/blueprints.py
+++ b/ckanext/versions/blueprints.py
@@ -29,11 +29,17 @@ def version_download(id, resource_id, version):
     except toolkit.NotFound:
         toolkit.abort(404, toolkit._(u'Activity not found'))
 
-    download_url = toolkit.url_for('resource.download',
-                                    id=id,
-                                    resource_id=resource_id,
-                                    activity_id=activity_id,
-                                    qualified=True)
+    download_url = toolkit.url_for(
+        'resource.download',
+        id=id,
+        resource_id=resource_id,
+        activity_id=activity_id,
+        qualified=True
+        )
     return toolkit.redirect_to(download_url)
 
-blueprint.add_url_rule(u'/dataset/<id>/resource/<resource_id>/v/<version>/download', view_func=version_download)
+
+blueprint.add_url_rule(
+    u'/dataset/<id>/resource/<resource_id>/v/<version>/download',
+    view_func=version_download
+    )

--- a/ckanext/versions/blueprints.py
+++ b/ckanext/versions/blueprints.py
@@ -1,0 +1,40 @@
+from flask import Blueprint
+
+from ckan import model
+from ckan.plugins import toolkit
+
+from ckanext.versions.logic import action
+
+blueprint = Blueprint(
+    'versions',
+    __name__,
+)
+
+
+def version_download(id, resource_id, version):
+    """Download resource blueprint supporting version name.
+
+    This download blueprint gets the activity_id from the version and redirects
+    to a download url that can handle it. Currently is working with
+    blob_storage extension but can work with any download endpoint that knows
+    how to handle activities for resources.
+    """
+    context = {
+        'model': model,
+        'user': toolkit.c.user
+    }
+
+    try:
+        activity_id = action.get_activity_id_from_resource_version_name(
+            context, {'resource_id': resource_id, 'version_name': version})
+    except toolkit.NotFound:
+        toolkit.abort(404, toolkit._(u'Activity not found'))
+
+    download_url = toolkit.url_for('resource.download',
+                                    id=id,
+                                    resource_id=resource_id,
+                                    activity_id=activity_id,
+                                    qualified=True)
+    return toolkit.redirect_to(download_url)
+
+blueprint.add_url_rule(u'/dataset/<id>/resource/<resource_id>/v/<version>/download', view_func=version_download)

--- a/ckanext/versions/blueprints.py
+++ b/ckanext/versions/blueprints.py
@@ -1,7 +1,6 @@
-from flask import Blueprint
-
 from ckan import model
 from ckan.plugins import toolkit
+from flask import Blueprint
 
 from ckanext.versions.logic import action
 

--- a/ckanext/versions/helpers.py
+++ b/ckanext/versions/helpers.py
@@ -71,7 +71,7 @@ def download_url(resource_url, version_name):
         return resource_url
 
     base_resource_url, filename = resource_url.split("/download/")
-    url = "{}/v/{}/download/{}".format(
+    url = "{}/version/{}/download/{}".format(
         base_resource_url,
         version_name,
         filename

--- a/ckanext/versions/helpers.py
+++ b/ckanext/versions/helpers.py
@@ -10,13 +10,13 @@ def resources_list_with_current_version(resources):
             'resource_id': resource['id']}
             )
         if versions_list:
-           resource['version'] = versions_list[0]['name']
-           resource['version_url'] = toolkit.url_for(
-               'resource.read',
-               id=versions_list[0]['package_id'],
-               resource_id=versions_list[0]['resource_id'],
-               activity_id=versions_list[0]['activity_id']
-               )
+            resource['version'] = versions_list[0]['name']
+            resource['version_url'] = toolkit.url_for(
+                'resource.read',
+                id=versions_list[0]['package_id'],
+                resource_id=versions_list[0]['resource_id'],
+                activity_id=versions_list[0]['activity_id']
+                )
     return resources
 
 
@@ -30,7 +30,7 @@ def resource_version_list(resource):
     return resource_version_list
 
 
-def resource_version_from_activity_id(resource, activity_id ):
+def resource_version_from_activity_id(resource, activity_id):
     '''Get the resource version filtering for the given activity_id.
 
     '''
@@ -52,7 +52,8 @@ def resource_current_version(resource):
             'resource_id': resource['id']}
             )
     if versions_list:
-        current_version = toolkit.get_action('resource_version_current')(context, {
-                'resource_id': resource['id']})
+        current_version = toolkit.get_action('resource_version_current')(
+            context, {'resource_id': resource['id']}
+            )
         return current_version
     return False

--- a/ckanext/versions/helpers.py
+++ b/ckanext/versions/helpers.py
@@ -1,5 +1,6 @@
 from ckan.plugins import toolkit
 
+
 def resources_list_with_current_version(resources):
     '''Get the resource list and with name and url of the latest version.
     '''

--- a/ckanext/versions/helpers.py
+++ b/ckanext/versions/helpers.py
@@ -57,3 +57,24 @@ def resource_current_version(resource):
             )
         return current_version
     return False
+
+
+def download_url(resource_url, version_name):
+    '''Returns a url to download the specific version of the resource.
+
+    This method is to be used in templates, it takes the default download URL
+    and edits it to point to the endpoint for the specific version of the
+    resource.
+    '''
+    site_url = toolkit.config.get("ckan.site_url")
+    if not resource_url.startswith(site_url):
+        return resource_url
+
+    base_resource_url, filename = resource_url.split("/download/")
+    url = "{}/v/{}/download/{}".format(
+        base_resource_url,
+        version_name,
+        filename
+        )
+
+    return url

--- a/ckanext/versions/helpers.py
+++ b/ckanext/versions/helpers.py
@@ -59,7 +59,7 @@ def resource_current_version(resource):
     return False
 
 
-def download_url(resource_url, version_name):
+def download_url(resource_url, version_id):
     '''Returns a url to download the specific version of the resource.
 
     This method is to be used in templates, it takes the default download URL
@@ -73,7 +73,7 @@ def download_url(resource_url, version_name):
     base_resource_url, filename = resource_url.split("/download/")
     url = "{}/version/{}/download/{}".format(
         base_resource_url,
-        version_name,
+        version_id,
         filename
         )
 

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -233,14 +233,13 @@ def resource_history(context, data_dict):
 
     result = []
     for version in versions_list:
-            resource = activity_resource_show({
-                'user': context['user']
-            },
-            {
-                'activity_id': version['activity_id'],
-                'resource_id': version['resource_id']
-            }
-            )
+            resource = activity_resource_show(
+                {'user': context['user']},
+                {
+                    'activity_id': version['activity_id'],
+                    'resource_id': version['resource_id']
+                }
+                )
             resource['version'] = version
             result.append(resource)
 
@@ -257,7 +256,8 @@ def activity_resource_show(context, data_dict):
     :returns: The resource in the activity
     :rtype: dict
     '''
-    activity_id, resource_id = toolkit.get_or_bust(data_dict,
+    activity_id, resource_id = toolkit.get_or_bust(
+        data_dict,
         ['activity_id', 'resource_id']
         )
 
@@ -340,6 +340,7 @@ def _generate_diff(obj1, obj2, diff_type):
         raise toolkit.ValidationError('diff_type not recognized')
 
     return diff
+
 
 @toolkit.chained_action
 def resource_view_list(up_func, context, data_dict):

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -358,3 +358,24 @@ def resource_view_list(up_func, context, data_dict):
     resource_views.extend(versions_views)
 
     return resource_views
+
+
+def get_activity_id_from_resource_version_name(context, data_dict):
+    ''' Returns the activity_id for the resource version
+
+    :param resource_id: the id of the resource
+    :type resource_id: string
+    :param version: the name of the version
+    :type version: string
+    :returns: The activity_id of the version
+    :rtype: string
+
+    '''
+    version_name = data_dict.get('version_name')
+    version_list = resource_version_list(context, data_dict)
+
+    for version in version_list:
+        if version['name'] == version_name:
+            return version['activity_id']
+
+    raise toolkit.NotFound('Version not found in the resource.')

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -66,7 +66,7 @@ def version_update(context, data_dict):
 
 
 def resource_version_create(context, data_dict):
-    """Create a new version from the current dataset's revision
+    """Create a new version from the current dataset's activity_id
 
     Currently you must have editor level access on the dataset
     to create a version.
@@ -75,7 +75,7 @@ def resource_version_create(context, data_dict):
     :type resource_id: string
     :param name: A short name for the version
     :type name: string
-    :param notes: A description for the version
+    :param notes optional: A description for the version
     :type notes: string
     :returns: the newly created version
     :rtype: dictionary
@@ -102,7 +102,7 @@ def resource_version_create(context, data_dict):
         package_id=resource.package_id,
         resource_id=data_dict['resource_id'],
         activity_id=activity.id,
-        name=data_dict.get('name', None),
+        name=name,
         notes=data_dict.get('notes', None),
         created=datetime.utcnow(),
         creator_user_id=context['auth_user_obj'].id)

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -72,6 +72,7 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'versions_resource_version_list': helpers.resource_version_list,
             'versions_resource_version_from_activity_id': helpers.resource_version_from_activity_id,
             'versions_resource_current_version': helpers.resource_current_version,
+            'versions_download_url': helpers.download_url,
         }
         return helper_functions
 

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -5,9 +5,9 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
 from ckanext.versions import cli, helpers
+from ckanext.versions.blueprints import blueprint
 from ckanext.versions.logic import action, auth
 from ckanext.versions.model import tables_exist
-from ckanext.versions.blueprints import blueprint
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -7,6 +7,7 @@ import ckan.plugins.toolkit as toolkit
 from ckanext.versions import cli, helpers
 from ckanext.versions.logic import action, auth
 from ckanext.versions.model import tables_exist
+from ckanext.versions.blueprints import blueprint
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +19,7 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IClick)
     plugins.implements(plugins.IResourceView)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IBlueprint)
 
     # IClick
 
@@ -72,6 +74,10 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'versions_resource_current_version': helpers.resource_current_version,
         }
         return helper_functions
+
+    # IBlueprints
+    def get_blueprint(self):
+        return blueprint
 
     # IResourceView
 

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -260,8 +260,8 @@ class TestVersionShow(object):
                 'resource_id': resource['id'],
                 'name': '1',
                 'notes': 'Version notes'
-            }
-        )
+                }
+                )
 
         result = version_show(context, {'version_id': version['id']})
 
@@ -388,9 +388,8 @@ class TestActivityActions(object):
 @pytest.mark.usefixtures('clean_db', 'versions_setup')
 class TestResourceView(object):
     def test_resource_view_list_returns_versions_view_last(self):
-        user = factories.Sysadmin()
         org = factories.Organization()
-        dataset = factories.Dataset(owner_org = org['id'])
+        dataset = factories.Dataset(owner_org=org['id'])
         resource = factories.Resource(
             package_id=dataset['id']
         )
@@ -409,7 +408,7 @@ class TestResourceView(object):
             'description': 'A nice versions view',
         }
 
-        versions_view = helpers.call_action('resource_view_create',**versions_view_dict)
+        versions_view = helpers.call_action('resource_view_create', **versions_view_dict)
         image_view = helpers.call_action('resource_view_create', **image_view_dict)
 
         resource_views = helpers.call_action('resource_view_list', id=resource['id'])
@@ -417,10 +416,9 @@ class TestResourceView(object):
         assert resource_views[0]['id'] == image_view['id']
         assert resource_views[1]['id'] == versions_view['id']
 
-    def test_resource_view_list_returns_versions_view_last(self):
-        user = factories.Sysadmin()
+    def test_resource_view_list_returns_default_order_if_no_versions_view(self):
         org = factories.Organization()
-        dataset = factories.Dataset(owner_org = org['id'])
+        dataset = factories.Dataset(owner_org=org['id'])
         resource = factories.Resource(
             package_id=dataset['id']
         )
@@ -439,7 +437,7 @@ class TestResourceView(object):
             'image_url': 'url',
         }
 
-        image_view = helpers.call_action('resource_view_create',**image_view_dict)
+        image_view = helpers.call_action('resource_view_create', **image_view_dict)
         image_view_2 = helpers.call_action('resource_view_create', **image_view_dict_2)
 
         resource_views = helpers.call_action('resource_view_list', id=resource['id'])

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -2,12 +2,10 @@ import pytest
 from ckan.plugins import toolkit
 from ckan.tests import factories, helpers
 
-from ckanext.versions.logic.action import (activity_resource_show,
-                                           get_activity_id_from_resource_version_name,
-                                           resource_version_create,
-                                           resource_version_current,
-                                           resource_version_list,
-                                           version_delete, version_show)
+from ckanext.versions.logic.action import (
+    activity_resource_show, get_activity_id_from_resource_version_name,
+    resource_version_create, resource_version_current, resource_version_list,
+    version_delete, version_show)
 from ckanext.versions.tests import get_context
 
 

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -3,6 +3,7 @@ from ckan.plugins import toolkit
 from ckan.tests import factories, helpers
 
 from ckanext.versions.logic.action import (activity_resource_show,
+                                           get_activity_id_from_resource_version_name,
                                            resource_version_create,
                                            resource_version_current,
                                            resource_version_list,
@@ -355,6 +356,36 @@ class TestActivityActions(object):
 
         assert activity_resource_2
         assert activity_resource_2['name'] == 'Second name'
+
+    def test_get_activity_id_from_resource_version_name(self):
+        user = factories.User()
+        owner_org = factories.Organization(
+            users=[{'name': user['name'], 'capacity': 'editor'}]
+        )
+        dataset = factories.Dataset(owner_org=owner_org['id'])
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            name='First name'
+            )
+
+        context = get_context(user)
+
+        version = resource_version_create(
+            context, {
+                'resource_id': resource['id'],
+                'name': '1',
+                'notes': 'Version notes'
+            }
+        )
+        expected_activity_id = version['activity_id']
+
+        activity_id = get_activity_id_from_resource_version_name(
+            context,
+            {'resource_id': resource['id'], 'version_name': version['name']}
+        )
+
+        assert expected_activity_id == activity_id
+
 
 @pytest.mark.usefixtures('clean_db', 'versions_setup')
 class TestResourceView(object):

--- a/ckanext/versions/tests/test_helpers.py
+++ b/ckanext/versions/tests/test_helpers.py
@@ -5,22 +5,22 @@ from ckanext.versions import helpers
 @pytest.mark.ckan_config('ckan.site_url', 'http://ckan:5000')
 def test_version_download_url_without_filename():
     url = 'http://ckan:5000/dataset/<id>/resource/<resource_id>/download/'
-    download_url = helpers.download_url(url, 'v1.0')
+    download_url = helpers.download_url(url, '<version_id>')
 
-    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/version/v1.0/download/'
+    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/version/<version_id>/download/'
 
 
 @pytest.mark.ckan_config('ckan.site_url', 'http://ckan:5000')
 def test_version_download_url_with_filename():
     url = 'http://ckan:5000/dataset/<id>/resource/<resource_id>/download/filename.csv'
-    download_url = helpers.download_url(url, 'v1.0')
+    download_url = helpers.download_url(url, '<version_id>')
 
-    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/version/v1.0/download/filename.csv'
+    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/version/<version_id>/download/filename.csv'
 
 
 @pytest.mark.ckan_config('ckan.site_url', 'http://ckan:5000')
 def test_version_download_url_with_external_url():
     url = 'https://www.my-external-url.com/external-filename.csv'
-    download_url = helpers.download_url(url, 'v1.0')
+    download_url = helpers.download_url(url, '<version_id>')
 
     assert download_url == url

--- a/ckanext/versions/tests/test_helpers.py
+++ b/ckanext/versions/tests/test_helpers.py
@@ -2,6 +2,7 @@ import pytest
 
 from ckanext.versions import helpers
 
+@pytest.mark.ckan_config('ckan.site_url', 'http://ckan:5000')
 def test_version_download_url_without_filename():
     url = 'http://ckan:5000/dataset/<id>/resource/<resource_id>/download/'
     download_url = helpers.download_url(url, 'v1.0')
@@ -9,6 +10,7 @@ def test_version_download_url_without_filename():
     assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/v/v1.0/download/'
 
 
+@pytest.mark.ckan_config('ckan.site_url', 'http://ckan:5000')
 def test_version_download_url_with_filename():
     url = 'http://ckan:5000/dataset/<id>/resource/<resource_id>/download/filename.csv'
     download_url = helpers.download_url(url, 'v1.0')
@@ -16,6 +18,7 @@ def test_version_download_url_with_filename():
     assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/v/v1.0/download/filename.csv'
 
 
+@pytest.mark.ckan_config('ckan.site_url', 'http://ckan:5000')
 def test_version_download_url_with_external_url():
     url = 'https://www.my-external-url.com/external-filename.csv'
     download_url = helpers.download_url(url, 'v1.0')

--- a/ckanext/versions/tests/test_helpers.py
+++ b/ckanext/versions/tests/test_helpers.py
@@ -7,7 +7,7 @@ def test_version_download_url_without_filename():
     url = 'http://ckan:5000/dataset/<id>/resource/<resource_id>/download/'
     download_url = helpers.download_url(url, 'v1.0')
 
-    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/v/v1.0/download/'
+    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/version/v1.0/download/'
 
 
 @pytest.mark.ckan_config('ckan.site_url', 'http://ckan:5000')
@@ -15,7 +15,7 @@ def test_version_download_url_with_filename():
     url = 'http://ckan:5000/dataset/<id>/resource/<resource_id>/download/filename.csv'
     download_url = helpers.download_url(url, 'v1.0')
 
-    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/v/v1.0/download/filename.csv'
+    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/version/v1.0/download/filename.csv'
 
 
 @pytest.mark.ckan_config('ckan.site_url', 'http://ckan:5000')

--- a/ckanext/versions/tests/test_helpers.py
+++ b/ckanext/versions/tests/test_helpers.py
@@ -1,0 +1,23 @@
+import pytest
+
+from ckanext.versions import helpers
+
+def test_version_download_url_without_filename():
+    url = 'http://ckan:5000/dataset/<id>/resource/<resource_id>/download/'
+    download_url = helpers.download_url(url, 'v1.0')
+
+    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/v/v1.0/download/'
+
+
+def test_version_download_url_with_filename():
+    url = 'http://ckan:5000/dataset/<id>/resource/<resource_id>/download/filename.csv'
+    download_url = helpers.download_url(url, 'v1.0')
+
+    assert download_url == 'http://ckan:5000/dataset/<id>/resource/<resource_id>/v/v1.0/download/filename.csv'
+
+
+def test_version_download_url_with_external_url():
+    url = 'https://www.my-external-url.com/external-filename.csv'
+    download_url = helpers.download_url(url, 'v1.0')
+
+    assert download_url == url


### PR DESCRIPTION
This PR implements a blueprint to handle the download of resource versions.

The new blueprint gets the activity_id from the version and redirects to a URL that can handle the download of files for previous activities of the resource. Currently it is working with `ckanext-blob-storage` (thanks [to this PR](https://github.com/datopian/ckanext-blob-storage/pull/57)) but any other extension that knows how to handle an extra `activity_id` parameter in the download endpoint should also work.

The new endpoint is: `/dataset/<dataset_id>/resource/<resource_id>/v/<version_name>/download`