### PR TITLE
Fix context in can_view method

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -380,3 +380,17 @@ def get_activity_id_from_resource_version_name(context, data_dict):
             return version['activity_id']
 
     raise toolkit.NotFound('Version not found in the resource.')
+
+
+def resource_has_versions(context, data_dict):
+    """Check if the resource has versions.
+
+    :param resource_id: the id the resource
+    :type resource_id: string
+    :returns: True if the resource has at least 1 version
+    :rtype: boolean
+    """
+    version_list = resource_version_list(context, data_dict)
+    if not version_list:
+        return False
+    return True

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -93,13 +93,8 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         context = {'ignore_auth': True}
         resource = data_dict['resource']
         resource_id = resource.get('id')
-        version_list = action.resource_version_list(
-            context, {'resource_id': resource_id}
-            )
 
-        if not version_list:
-            return False
-        return True
+        return action.resource_has_versions(context, {'resource_id': resource_id})
 
     def setup_template_variables(self, context, data_dict):
         context = {'user': toolkit.c.user}

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -90,11 +90,11 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
                 'iframed': False}
 
     def can_view(self, data_dict):
-        context = {'user': toolkit.c.user}
+        context = {'ignore_auth': True}
         resource = data_dict['resource']
         resource_id = resource.get('id')
-        version_list = action.resource_version_list(context, {
-            'resource_id': resource_id}
+        version_list = action.resource_version_list(
+            context, {'resource_id': resource_id}
             )
 
         if not version_list:

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -4,8 +4,8 @@ from ckan.tests import factories, helpers
 
 from ckanext.versions.logic.action import (
     activity_resource_show, get_activity_id_from_resource_version_name,
-    resource_version_create, resource_version_current, resource_version_list,
-    version_delete, version_show)
+    resource_has_versions, resource_has_versions, resource_version_create, resource_version_current,
+    resource_version_list, version_delete, version_show)
 from ckanext.versions.tests import get_context
 
 
@@ -156,6 +156,31 @@ class TestCreateResourceVersion(object):
 
         assert activity_resource['id'] == resource['id']
         assert activity_resource['name'] == 'Second Name'
+
+    def test_resource_has_version(self):
+        dataset = factories.Dataset()
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            name='First name'
+            )
+        user = factories.Sysadmin()
+        context = get_context(user)
+
+        assert False == resource_has_versions(
+            context, {'resource_id': resource['id']}
+            )
+
+        resource_version_create(
+            context, {
+                'resource_id': resource['id'],
+                'name': '1',
+                'notes': 'Version notes'
+            }
+        )
+
+        assert True == resource_has_versions(
+            context, {'resource_id': resource['id']}
+            )
 
 
 @pytest.mark.usefixtures('clean_db', 'versions_setup')


### PR DESCRIPTION
This PR fixes #24 .

Since we only need to validate if the resource has versions it is safe to pass `ignore_auth': True` in the context.