### PR TITLE
Add creator_user_id parameter in resource_version_create

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -94,7 +94,6 @@ def resource_version_create(context, data_dict):
 
     toolkit.check_access('version_create', context,
                          {"package_id": resource.package_id})
-    assert context.get('auth_user_obj')  # Should be here after `check_access`
 
     creator_user_id = data_dict.get('creator_user_id')
     if creator_user_id:

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -69,7 +69,8 @@ def resource_version_create(context, data_dict):
     """Create a new version from the current dataset's activity_id
 
     Currently you must have editor level access on the dataset
-    to create a version.
+    to create a version. If creator_user_id is not present, it will be set as
+    the logged it user.
 
     :param resource_id: the id of the resource
     :type resource_id: string
@@ -77,6 +78,8 @@ def resource_version_create(context, data_dict):
     :type name: string
     :param notes optional: A description for the version
     :type notes: string
+    :param creator_user_id optional: the id of the creator
+    :type creator_user_id: string
     :returns: the newly created version
     :rtype: dictionary
     """
@@ -93,6 +96,14 @@ def resource_version_create(context, data_dict):
                          {"package_id": resource.package_id})
     assert context.get('auth_user_obj')  # Should be here after `check_access`
 
+    creator_user_id = data_dict.get('creator_user_id')
+    if creator_user_id:
+        creator_user = model.User.get(creator_user_id)
+        if not creator_user:
+            raise toolkit.ObjectNotFound('Creator user not found')
+    else:
+        creator_user_id = context['auth_user_obj'].id
+
     activity = model.Session.query(model.Activity). \
         filter_by(object_id=resource.package_id). \
         order_by(model.Activity.timestamp.desc()).\
@@ -105,7 +116,7 @@ def resource_version_create(context, data_dict):
         name=name,
         notes=data_dict.get('notes', None),
         created=datetime.utcnow(),
-        creator_user_id=context['auth_user_obj'].id)
+        creator_user_id=creator_user_id)
 
     model.Session.add(version)
 

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -182,6 +182,31 @@ class TestCreateResourceVersion(object):
             context, {'resource_id': resource['id']}
             )
 
+    def test_resource_version_create_creator_user_id_parameter(self):
+        user = factories.User()
+        owner_org = factories.Organization(
+            users=[{'name': user['name'], 'capacity': 'editor'}]
+        )
+        user_creator = factories.User()
+        dataset = factories.Dataset(owner_org=owner_org['id'])
+        resource = factories.Resource(package_id=dataset['id'])
+
+        version = resource_version_create(
+            get_context(user), {
+                'resource_id': resource['id'],
+                'name': '1',
+                'notes': 'Version notes',
+                'creator_user_id': user_creator['id']
+            }
+        )
+
+        assert version
+        assert version['package_id'] == dataset['id']
+        assert version['resource_id'] == resource['id']
+        assert version['notes'] == 'Version notes'
+        assert version['name'] == '1'
+        assert version['creator_user_id'] == user_creator['id']
+
 
 @pytest.mark.usefixtures('clean_db', 'versions_setup')
 class TestResourceVersionList(object):


### PR DESCRIPTION
This PR adds the `creator_user_id` parameter to `resource_version_create` and defaults to the logged user if non is provided.