### PR TITLE
Fail if activity doesn't exist

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -105,8 +105,11 @@ def resource_version_create(context, data_dict):
 
     activity = model.Session.query(model.Activity). \
         filter_by(object_id=resource.package_id). \
-        order_by(model.Activity.timestamp.desc()).\
+        order_by(model.Activity.timestamp.desc()). \
         first()
+
+    if not activity:
+        raise toolkit.ObjectNotFound('Activity not found')
 
     version = Version(
         package_id=resource.package_id,


### PR DESCRIPTION
Some packages may not have an activity so I'm adding a sanity check before accessing the object.

This may happen, for example:
 - if the instance is migrated from CKAN 2.8 to 2.9 and the dataset has not been edited since then or 
 - if the revision migration to activities failed (or if it wasn't made)
 - if data is corrupted