### PR TITLE
Raise exception if the activity doesn't contain resource

### DIFF
--- a/ckanext/versions/blueprints.py
+++ b/ckanext/versions/blueprints.py
@@ -28,7 +28,7 @@ def version_download(id, resource_id, version_id):
             context, {'resource_id': resource_id, 'version_id': version_id}
             )
         activity_id = version['activity_id']
-    except toolkit.NotFound:
+    except toolkit.ObjectNotFound:
         toolkit.abort(404, toolkit._(u'Version not found'))
 
     download_url = toolkit.url_for(

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -111,12 +111,12 @@ def resource_version_create(context, data_dict):
     if not activity:
         raise toolkit.ObjectNotFound('Activity not found')
 
-    if not resource_in_activity(context, data_dict):
+    if not resource_in_activity(context, {'activity_id': activity.id, 'resource_id': resource_id}):
         raise toolkit.ObjectNotFound('Resource not found in the activity.')
 
     version = Version(
         package_id=resource.package_id,
-        resource_id=data_dict['resource_id'],
+        resource_id=resource_id,
         activity_id=activity.id,
         name=name,
         notes=data_dict.get('notes', None),

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -297,7 +297,7 @@ def resource_in_activity(context, data_dict):
     ''' Check if the resource exists in the activity object.
 
     This method can be use as a sanity check to validate that the activity_id
-    assigned to the resource contains the resource.
+    assigned to the resource version contains the resource.
 
     :param activity_id: the id of the activity
     :type activity_id: string

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -288,7 +288,7 @@ def activity_resource_show(context, data_dict):
             break
 
     if not old_resource:
-        raise toolkit.NotFound('Resource not found in the activity object.')
+        raise toolkit.ObjectNotFound('Resource not found in the activity object.')
 
     return old_resource
 
@@ -308,7 +308,7 @@ def resource_in_activity(context, data_dict):
     '''
     try:
         activity_resource_show(context, data_dict)
-    except toolkit.NotFound:
+    except toolkit.ObjectNotFound:
         return False
     return True
 
@@ -415,7 +415,7 @@ def get_activity_id_from_resource_version_name(context, data_dict):
         if version['name'] == version_name:
             return version['activity_id']
 
-    raise toolkit.NotFound('Version not found in the resource.')
+    raise toolkit.ObjectNotFound('Version not found in the resource.')
 
 
 def resource_has_versions(context, data_dict):

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -111,6 +111,9 @@ def resource_version_create(context, data_dict):
     if not activity:
         raise toolkit.ObjectNotFound('Activity not found')
 
+    if not resource_in_activity(context, data_dict):
+        raise toolkit.ObjectNotFound('Resource not found in the activity.')
+
     version = Version(
         package_id=resource.package_id,
         resource_id=data_dict['resource_id'],
@@ -288,6 +291,26 @@ def activity_resource_show(context, data_dict):
         raise toolkit.NotFound('Resource not found in the activity object.')
 
     return old_resource
+
+
+def resource_in_activity(context, data_dict):
+    ''' Check if the resource exists in the activity object.
+
+    This method can be use as a sanity check to validate that the activity_id
+    assigned to the resource contains the resource.
+
+    :param activity_id: the id of the activity
+    :type activity_id: string
+    :param resource_id: the id of the resource
+    :type resource_id: string
+    :returns: True if the resource exist in the activity
+    :rtype: boolean
+    '''
+    try:
+        activity_resource_show(context, data_dict)
+    except toolkit.NotFound:
+        return False
+    return True
 
 
 def _get_resource_in_revision(context, data_dict, revision_id):

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -445,10 +445,6 @@ class TestActivityActions(object):
             package_id=dataset['id'],
             name='Resource 1'
             )
-        resource_2 = factories.Resource(
-            package_id=dataset['id'],
-            name='Resource 2'
-            )
 
         context = get_context(user)
 
@@ -464,6 +460,11 @@ class TestActivityActions(object):
         assert True == resource_in_activity(context, {
             'activity_id': expected_activity_id,
             'resource_id': resource['id']}
+            )
+
+        resource_2 = factories.Resource(
+            package_id=dataset['id'],
+            name='Resource 2'
             )
 
         assert False == resource_in_activity(context, {


### PR DESCRIPTION
When creating a new version it may happen that the last activity of the package (the one that's gonna be assigned) don't contain the resource itself. (Corrupted activity history most probably)

To avoid this situation I added a sanity check before creating the version and Raise an exception since it does not make sense to have Resource Version pointing to an activity that doesn't contain the resource.