### PR TITLE
Fix missing user in non-requests context

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -308,11 +308,12 @@ def resource_in_activity(context, data_dict):
     '''
     user = context.get('user')
     if not user:
-        user = toolkit.get_action('get_site_user')({'ignore_auth': True},{})
+        site_user = toolkit.get_action('get_site_user')({'ignore_auth': True},{})
+        user = site_user['name']
 
     activity_show_context = {
         'model': core_model,
-        'user': user['name']
+        'user': user
     }
 
     try:

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -306,8 +306,17 @@ def resource_in_activity(context, data_dict):
     :returns: True if the resource exist in the activity
     :rtype: boolean
     '''
+    user = context.get('user')
+    if not user:
+        user = toolkit.get_action('get_site_user')({'ignore_auth': True},{})
+
+    activity_show_context = {
+        'model': core_model,
+        'user': user['name']
+    }
+
     try:
-        activity_resource_show(context, data_dict)
+        activity_resource_show(activity_show_context, data_dict)
     except toolkit.ObjectNotFound:
         return False
     return True


### PR DESCRIPTION
`activity_show` method requires an user to be set in the context. In order to be able to execute the call to the action in non-requests context (like CLI tools) I'm adding the default site user to the context if not present in the context object.