### PR TITLE
Check resources key exist

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -281,8 +281,13 @@ def activity_resource_show(context, data_dict):
                 {'model': core_model, 'user': context['user']},
                 {'id': activity_id, 'object_type': 'package'}
                 )
+
+    resources = package.get('resources')
+    if not resources:
+        raise toolkit.ObjectNotFound('Resource not found in the activity object.')
+
     old_resource = None
-    for res in package['resources']:
+    for res in resources:
         if res['id'] == resource_id:
             old_resource = res
             break


### PR DESCRIPTION
Some activity data may not have a resource key. Adding a validation before trying to access the value.