### PR TITLE
Fix resource_version_current when there are no versions

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -209,7 +209,7 @@ def resource_version_current(context, data_dict):
     :rtype dict
     '''
     version_list = resource_version_list(context, data_dict)
-    return version_list[0]
+    return version_list[0] if version_list else None
 
 
 def resource_history(context, data_dict):

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -243,6 +243,12 @@ class TestResourceVersionList(object):
         assert current_version['name'] == '2'
         assert current_version['notes'] == 'Notes for version 2'
 
+    def test_resource_version_current_no_versions(self):
+        resource = factories.Resource(
+            name='First name'
+        )
+        assert helpers.call_action('resource_version_current', {}, resource_id=resource['id']) is None
+
 
 @pytest.mark.usefixtures('clean_db', 'versions_setup')
 class TestVersionShow(object):


### PR DESCRIPTION
Called on a resource without versions, it raised `IndexError`. It now returns `None`