### PR TITLE
Small changes to make running tests easier

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -101,7 +101,13 @@ def resource_version_create(context, data_dict):
         if not creator_user:
             raise toolkit.ObjectNotFound('Creator user not found')
     else:
-        creator_user_id = context['auth_user_obj'].id
+        if context.get('user'):
+            user = model.User.get(context['user'])
+            if user:
+                creator_user_id = user.id
+        if not creator_user_id:
+            site_id = toolkit.config.get('ckan.site_id', 'ckan_site_user')
+            creator_user_id = model.User.get(site_id).id
 
     activity = model.Session.query(model.Activity). \
         filter_by(object_id=resource.package_id). \

--- a/ckanext/versions/model.py
+++ b/ckanext/versions/model.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 from ckan.model.meta import metadata
 from ckan.model.types import UuidType
-from sqlalchemy import (Column, DateTime, ForeignKey, Unicode,
+from sqlalchemy import (Column, DateTime, Unicode,
                         UniqueConstraint, orm)
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -22,12 +22,12 @@ class Version(Base):
     )
 
     id = Column(UuidType, primary_key=True, default=UuidType.default)
-    package_id = Column(UuidType, ForeignKey('package.id'), nullable=False)
-    resource_id = Column(UuidType, ForeignKey('resource.id'), nullable=True)
-    activity_id = Column(UuidType, ForeignKey('activity.id'), nullable=False)
+    package_id = Column(UuidType, nullable=False)
+    resource_id = Column(UuidType, nullable=True)
+    activity_id = Column(UuidType, nullable=False)
     name = Column(Unicode, nullable=False)
     notes = Column(Unicode, nullable=True)
-    creator_user_id = Column(UuidType, ForeignKey('user.id'), nullable=False)
+    creator_user_id = Column(UuidType, nullable=False)
     created = Column(DateTime, default=datetime.datetime.utcnow)
 
     def as_dict(self):


### PR DESCRIPTION
* Fallback to context and site users for creator_user_id: Depending on how tests are run, you can't rely on
`context['auth_user_object']` being there. These changes fallback to `context['user']` and the site user if a user can't be found. It should only happen in tests.

* Remove Foreign Key definitions

While foreign keys are obviously a good way of ensure data integrity, creating foreign keys against core tables is discouraged at introduces issues when deleting core entities, specially in tests, eg

```
E       IntegrityError: (psycopg2.errors.ForeignKeyViolation) update or
	delete on table "resource" violates foreign key constraint
	"version_resource_id_fkey" on table "version"
E       DETAIL:  Key (id)=(f5e2d99c-5e35-4429-848b-da17d1974b53) is still
	referenced from table "version".
E
E       [SQL: delete from "resource"]
E       (Background on this error at: http://sqlalche.me/e/gkpj)
```

See
https://docs.ckan.org/en/2.9/extensions/best-practices.html?#don-t-edit-ckan-s-database-tables