### PR TITLE
Prevent NonAuthorized error on Version history for non-editors

### DIFF
--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -307,12 +307,15 @@ def activity_resource_show(context, data_dict):
     activity_id, resource_id = toolkit.get_or_bust(
         data_dict,
         ['activity_id', 'resource_id']
-        )
+    )
+
+    # Ensure we are not leaking info to unauthorized users
+    toolkit.check_access('resource_show', context, {'id': resource_id})
 
     package = toolkit.get_action('activity_data_show')(
-                {'model': core_model, 'user': context['user']},
-                {'id': activity_id, 'object_type': 'package'}
-                )
+        {'user': toolkit.get_action('get_site_user')({'ignore_auth': True})['name']},
+        {'id': activity_id, 'object_type': 'package'}
+    )
 
     resources = package.get('resources')
     if not resources:

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -435,6 +435,39 @@ class TestActivityActions(object):
         assert activity_resource_2
         assert activity_resource_2['name'] == 'Second name'
 
+    def test_activity_resource_shows_works_on_non_editors(self):
+        user = factories.User()
+        owner_org = factories.Organization(
+            users=[{'name': user['name'], 'capacity': 'editor'}]
+        )
+        dataset = factories.Dataset(owner_org=owner_org['id'])
+        resource = factories.Resource(
+            package_id=dataset['id'],
+            name='First name'
+        )
+
+        context = get_context(user)
+
+        version = resource_version_create(
+            context, {
+                'resource_id': resource['id'],
+                'name': '1',
+                'notes': 'Version notes'
+            }
+        )
+
+        user2 = factories.User()
+
+        activity_resource = activity_resource_show(
+            {'user': user2['name']}, {
+                'activity_id': version['activity_id'],
+                'resource_id': resource['id']
+            }
+        )
+
+        assert activity_resource
+        assert activity_resource['name'] == 'First name'
+
     def test_get_activity_id_from_resource_version_name(self):
         user = factories.User()
         owner_org = factories.Organization(


### PR DESCRIPTION
Pass internal site users to the `activity_data_show` call to ensure you don't need edit rights to get it. Do a `check_access('resource_show')` before to ensure only users that can see the resource can call this
function