### PR TITLE
Refactor resource_current_version helper

### DIFF
--- a/ckanext/versions/helpers.py
+++ b/ckanext/versions/helpers.py
@@ -44,19 +44,14 @@ def resource_version_from_activity_id(resource, activity_id):
     return []
 
 
-def resource_current_version(resource):
+def resource_version_current(resource):
     '''Get the resource current version
     '''
     context = {'user': toolkit.c.user}
-    versions_list = toolkit.get_action('resource_version_list')(context, {
-            'resource_id': resource['id']}
-            )
-    if versions_list:
-        current_version = toolkit.get_action('resource_version_current')(
-            context, {'resource_id': resource['id']}
-            )
-        return current_version
-    return False
+    version = toolkit.get_action('resource_version_current')(
+        context, {'resource_id': resource['id']}
+        )
+    return version
 
 
 def download_url(resource_url, version_id):

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -73,7 +73,7 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'versions_resources_list_with_current_version': helpers.resources_list_with_current_version,
             'versions_resource_version_list': helpers.resource_version_list,
             'versions_resource_version_from_activity_id': helpers.resource_version_from_activity_id,
-            'versions_resource_current_version': helpers.resource_current_version,
+            'versions_resource_version_current': helpers.resource_version_current,
             'versions_download_url': helpers.download_url,
         }
         return helper_functions


### PR DESCRIPTION
This PR cleans unnecessary logic on the `resource_version_current` helper.

It also renames it to match the syntax of the action.