### PR TITLE
Update new resource_version_update action

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,9 +113,9 @@ resource_version_update::
                  -d "version_id=7eab640a-546a-4be1-97bf-9c7aa7a543ed"
                  -d "name=v2.0"
                  -d "notes=New name for this version!"
-                 -k "http://ckan:5000/api/action/version_delete"
+                 -k "http://ckan:5000/api/action/resource_version_update"
     {
-    "help": "http://ckan:5000/api/3/action/help_show?name=version_delete",
+    "help": "http://ckan:5000/api/3/action/help_show?name=resource_version_update",
     "success": true,
     "result": {
         "id": "7eab640a-546a-4be1-97bf-9c7aa7a543ed",
@@ -135,9 +135,9 @@ resource_version_patch::
                  -H "Content-Type: application/json;charset=utf-8"
                  -d "version_id=7eab640a-546a-4be1-97bf-9c7aa7a543ed"
                  -d "notes=Updating only notes!"
-                 -k "http://ckan:5000/api/action/version_delete"
+                 -k "http://ckan:5000/api/action/resource_version_patch"
     {
-    "help": "http://ckan:5000/api/3/action/help_show?name=version_delete",
+    "help": "http://ckan:5000/api/3/action/help_show?name=resource_version_patch",
     "success": true,
     "result": {
         "id": "7eab640a-546a-4be1-97bf-9c7aa7a543ed",

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ ckanext-versions
 =============
 
 This CKAN extension adds an ability to create and manage named resources
-versions in CKAN. Currently under development so there are no stable versions of it.
+versions in CKAN.
 
 Internally, this extension will use CKAN's 2.9 activities to preserve
 old revisions of metadata, and ensure uploaded data resources are unique
@@ -13,7 +13,7 @@ This extension is designed to be used with
 `ckanext-blob-storage <https://github.com/datopian/ckanext-blob-storage>`_
 
 As interface, this extension exposes a few new API actions described below. (no
-UI work yet)
+UI work)
 
 ------------
 API Endpoints
@@ -106,6 +106,50 @@ version_delete::
     "result": null
     }
 
+resource_version_update::
+
+    curl -X POST -H "Authorization: $API_KEY"
+                 -H "Content-Type: application/json;charset=utf-8"
+                 -d "version_id=7eab640a-546a-4be1-97bf-9c7aa7a543ed"
+                 -d "name=v2.0"
+                 -d "notes=New name for this version!"
+                 -k "http://ckan:5000/api/action/version_delete"
+    {
+    "help": "http://ckan:5000/api/3/action/help_show?name=version_delete",
+    "success": true,
+    "result": {
+        "id": "7eab640a-546a-4be1-97bf-9c7aa7a543ed",
+        "package_id": "9a2ca5e4-1018-479d-8365-9e2f54c69d26",
+        "resource_id": "9509ca60-a113-4d3b-8afa-83172b87368a",
+        "activity_id": "2efbf349-5c66-4d4a-8c22-8dc31db7453a",
+        "name": "v2.0",
+        "notes": "New name for this version!",
+        "creator_user_id": "62f05721-fb2f-453f-9816-702f9c9f76c6",
+        "created": "2021-05-15 21:01:30.980231"
+      }
+    }
+
+resource_version_patch::
+
+    curl -X POST -H "Authorization: $API_KEY"
+                 -H "Content-Type: application/json;charset=utf-8"
+                 -d "version_id=7eab640a-546a-4be1-97bf-9c7aa7a543ed"
+                 -d "notes=Updating only notes!"
+                 -k "http://ckan:5000/api/action/version_delete"
+    {
+    "help": "http://ckan:5000/api/3/action/help_show?name=version_delete",
+    "success": true,
+    "result": {
+        "id": "7eab640a-546a-4be1-97bf-9c7aa7a543ed",
+        "package_id": "9a2ca5e4-1018-479d-8365-9e2f54c69d26",
+        "resource_id": "9509ca60-a113-4d3b-8afa-83172b87368a",
+        "activity_id": "2efbf349-5c66-4d4a-8c22-8dc31db7453a",
+        "name": "v2.0",
+        "notes": "Updating only notes!",
+        "creator_user_id": "62f05721-fb2f-453f-9816-702f9c9f76c6",
+        "created": "2021-05-15 21:01:30.980231"
+      }
+    }
 
 ------------
 Download Endpoint

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -69,7 +69,6 @@ def resource_version_patch(context, data_dict):
     toolkit.check_access('version_create', context, {
         "package_id": version.package_id
     })
-    assert context.get('auth_user_obj')  # Should be here after `check_access`
 
     version.name = data_dict.get('name') or version.name
     version.notes = data_dict.get("notes") or version.notes
@@ -133,7 +132,6 @@ def resource_version_update(context, data_dict):
     toolkit.check_access('version_create', context, {
         "package_id": version.package_id
     })
-    assert context.get('auth_user_obj')  # Should be here after `check_access`
 
     version.name = name
     version.notes = data_dict.get("notes", None)

--- a/ckanext/versions/logic/action.py
+++ b/ckanext/versions/logic/action.py
@@ -15,11 +15,9 @@ from ckanext.versions.model import Version
 log = logging.getLogger(__name__)
 
 
-def version_update(context, data_dict):
-    """Update a version from the current dataset.
+def resource_version_update(context, data_dict):
+    """Update a version metadata.
 
-    :param package_id: the id the dataset
-    :type package_id: string
     :param version_id: the id of the version
     :type version_id: string
     :param name: A short name for the version
@@ -30,7 +28,7 @@ def version_update(context, data_dict):
     :rtype: dictionary
     """
     model = context.get('model', core_model)
-    version_id, name = toolkit.get_or_bust(data_dict, ['version', 'name'])
+    version_id = toolkit.get_or_bust(data_dict, ['version_id'])
 
     # I'll create my own session! With Blackjack! And H**kers!
     session = model.meta.create_local_session()
@@ -42,11 +40,16 @@ def version_update(context, data_dict):
     if not version:
         raise toolkit.ObjectNotFound('Version not found')
 
-    toolkit.check_access('dataset_version_create', context, data_dict)
+    toolkit.check_access('version_create', context, data_dict)
     assert context.get('auth_user_obj')  # Should be here after `check_access`
 
-    version.name = name
-    version.description = data_dict.get('description', None)
+    name = data_dict.get("name", None)
+    if name:
+        version.name = name
+
+    notes = data_dict.get("notes", None)
+    if notes:
+        version.notes = notes
 
     session.add(version)
 
@@ -60,7 +63,7 @@ def version_update(context, data_dict):
             'Version names must be unique per dataset'
         )
 
-    log.info('Version "%s" with id %s edited correctly', name, version_id)
+    log.info('Version "%s" with id %s edited correctly', version.name, version_id)
 
     return version.as_dict()
 

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -51,6 +51,7 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'resource_version_current': action.resource_version_current,
             'resource_version_clear': action.resource_version_clear,
             'resource_version_update': action.resource_version_update,
+            'resource_version_patch': action.resource_version_patch,
             'version_show': action.version_show,
             'version_delete': action.version_delete,
             'resource_view_list': action.resource_view_list,

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -50,6 +50,7 @@ class VersionsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
             'resource_version_list': action.resource_version_list,
             'resource_version_current': action.resource_version_current,
             'resource_version_clear': action.resource_version_clear,
+            'resource_version_update': action.resource_version_update,
             'version_show': action.version_show,
             'version_delete': action.version_delete,
             'resource_view_list': action.resource_view_list,

--- a/ckanext/versions/tests/test_actions.py
+++ b/ckanext/versions/tests/test_actions.py
@@ -8,8 +8,7 @@ from ckanext.versions.logic.action import (
     resource_has_versions, resource_in_activity,
     resource_version_create, resource_version_current,
     resource_version_list, version_delete, version_show,
-    resource_version_clear, resource_version_update,
-    resource_version_patch
+    resource_version_clear
 )
 from ckanext.versions.tests import get_context
 
@@ -219,22 +218,22 @@ class TestResourceVersionUpdate(object):
         resource = factories.Resource()
         user = factories.Sysadmin()
         context = get_context(user)
-        version = resource_version_create(
-            context, {
-                'resource_id': resource['id'],
-                'name': '1.0',
-                'notes': 'Initial notes.'
-            }
+        version = helpers.call_action(
+            'resource_version_create',
+            context,
+            resource_id=resource['id'],
+            name='1.0',
+            notes='Initial notes.'
         )
 
         new_creator = factories.User()
-        resource_version_update(
-            context, {
-                'version_id': version['id'],
-                'name': '2.0',
-                'notes': 'Updated notes.',
-                'creator_user_id': new_creator['id']
-            }
+        helpers.call_action(
+            'resource_version_update',
+            context,
+            version_id=version['id'],
+            name='2.0',
+            notes='Updated notes.',
+            creator_user_id=new_creator['id']
         )
         version = version_show(
             context, {'version_id': version['id']}
@@ -248,24 +247,26 @@ class TestResourceVersionUpdate(object):
         resource = factories.Resource()
         user = factories.Sysadmin()
         context = get_context(user)
-        version = resource_version_create(
-            context, {
-                'resource_id': resource['id'],
-                'name': '1.0',
-                'notes': 'Initial notes.'
-            }
+        version = helpers.call_action(
+            'resource_version_create',
+            context,
+            resource_id=resource['id'],
+            name='1.0',
+            notes='Initial notes.'
         )
 
         new_creator = factories.User()
         context = get_context(new_creator)
-        resource_version_update(
-            context, {
-                'version_id': version['id'],
-                'name': '2.0',
-            }
+        helpers.call_action(
+            'resource_version_update',
+            context,
+            version_id=version['id'],
+            name='2.0',
         )
-        version = version_show(
-            context, {'version_id': version['id']}
+        version = helpers.call_action(
+            'version_show',
+            context,
+            version_id=version['id']
         )
 
         assert version['name'] == '2.0'
@@ -276,32 +277,32 @@ class TestResourceVersionUpdate(object):
         resource = factories.Resource()
         user = factories.Sysadmin()
         context = get_context(user)
-        resource_version_create(
-            context, {
-                'resource_id': resource['id'],
-                'name': '1.0',
-                'notes': 'Initial notes.'
-            }
+        helpers.call_action(
+            'resource_version_create',
+            context,
+            resource_id=resource['id'],
+            name='1.0',
+            notes='Initial notes.'
         )
 
         with pytest.raises(toolkit.ValidationError):
-            resource_version_create(
-            context, {
-                'resource_id': resource['id'],
-                'name': '1.0',
-                'notes': 'Another version 1.0'
-            }
+            helpers.call_action(
+                'resource_version_create',
+                context,
+                resource_id=resource['id'],
+                name='1.0',
+                notes='Another version 1.0'
         )
 
     def test_version_id_is_mandatory_for_update(self):
         with pytest.raises(toolkit.ValidationError) as e:
-            resource_version_update({}, {'name': '2.0'})
+            helpers.call_action('resource_version_update', {}, name='2.0')
         assert 'Missing value' in str(e)
         assert 'version_id' in str(e)
 
     def test_version_name_is_mandatory_for_update(self):
         with pytest.raises(toolkit.ValidationError) as e:
-            resource_version_update({}, {'version_id': 'fake-id'})
+            helpers.call_action('resource_version_update', {}, version_id='fake-id')
         assert 'Missing value' in str(e)
         assert 'name' in str(e)
 
@@ -312,34 +313,36 @@ class TestResourceVersionPatch(object):
         resource = factories.Resource()
         user = factories.Sysadmin()
         context = get_context(user)
-        version = resource_version_create(
-            context, {
-                'resource_id': resource['id'],
-                'name': '1.0',
-                'notes': 'Initial notes.'
-            }
+        version = helpers.call_action(
+            'resource_version_create',
+            context,
+            resource_id=resource['id'],
+            name='1.0',
+            notes='Initial notes.'
         )
-        resource_version_patch(
-            context, {
-                'version_id': version['id'],
-                'name': '2.0'
-            }
+        helpers.call_action(
+            'resource_version_patch',
+            context,
+            version_id=version['id'],
+            name='2.0'
         )
-        version = version_show(
-            context, {'version_id': version['id']}
+        version = helpers.call_action(
+            'version_show', context, version_id=version['id']
         )
 
         assert version['name'] == '2.0'
         assert version['notes'] == 'Initial notes.'
 
-        resource_version_patch(
-            context, {
-                'version_id': version['id'],
-                'notes': 'Updated notes.'
-            }
+        helpers.call_action(
+            'resource_version_patch',
+            context,
+            version_id=version['id'],
+            notes='Updated notes.'
         )
-        version = version_show(
-            context, {'version_id': version['id']}
+        version = helpers.call_action(
+            'version_show',
+            context,
+            version_id=version['id']
         )
 
         assert version['name'] == '2.0'
@@ -349,25 +352,25 @@ class TestResourceVersionPatch(object):
         resource = factories.Resource()
         user = factories.Sysadmin()
         context = get_context(user)
-        resource_version_create(
-            context, {
-                'resource_id': resource['id'],
-                'name': '1.0',
-                'notes': 'Initial notes.'
-            }
+        helpers.call_action(
+            'resource_version_create',
+            context,
+            resource_id=resource['id'],
+            name='1.0',
+            notes='Initial notes.'
         )
 
         with pytest.raises(toolkit.ValidationError):
-            resource_version_create(
-            context, {
-                'resource_id': resource['id'],
-                'name': '1.0'
-            }
+            helpers.call_action(
+                'resource_version_create',
+                context,
+                resource_id=resource['id'],
+                name='1.0'
         )
 
     def test_version_id_is_mandatory_for_patch(self):
         with pytest.raises(toolkit.ValidationError) as e:
-            resource_version_patch({}, {'name': '2.0'})
+            helpers.call_action('resource_version_patch', {}, name='2.0')
 
         assert "Missing value" in str(e)
         assert "version_id" in str(e)


### PR DESCRIPTION
This PR refactors and adds new actions `resource_version_update` and `resource_version_patch` that allow users to edit a version metadata.

### Notes
- `resource_version_update` method follows CKAN's convention to perform a override of records (if fields are not they are removed). 
- `resource_version_patch` will edit only the field provided in the API call. 
- Only **name**, **notes** and **creator_user_id** fields can be updated.
- `version_id` and `name` are mandatory fields for `resource_version_update`

### Example Update:
```bash
$ curl -X POST http://localhost:5000/api/3/action/resource_version_update \
   -H "Authorization: $API_TOKEN" \
   -d "version_id=feef6b72-1156-4058-8cdd-8200b1534be3" \
   -d "notes=New notes" \
   -d "name=2.13"
{
  "help": "http://localhost:5000/api/3/action/help_show?name=resource_version_update",
  "success": true,
  "result": {
    "id": "feef6b72-1156-4058-8cdd-8200b1534be3",
    "package_id": "bd8cfa13-feba-425d-9d38-c6077dfb9cef",
    "resource_id": "37b54bf2-3fc1-4a40-b736-33744bb9aa1b",
    "activity_id": "dcd48169-4b8c-47c2-8f0b-7c11ca9221f6",
    "name": "2.3",
    "notes": "New notes",
    "creator_user_id": "8c0d7f45-1bf0-4e59-8e13-f7d6c5575822",
    "created": "2022-11-07 10:27:59.085900"
  }
}
```

### Example Patch:
```bash
$ curl -X POST http://localhost:5000/api/3/action/resource_version_update \
   -H "Authorization: $API_TOKEN" \
   -d "version_id=feef6b72-1156-4058-8cdd-8200b1534be3" \
   -d "notes=New notes with patch update" 
{
  "help": "http://localhost:5000/api/3/action/help_show?name=resource_version_patch",
  "success": true,
  "result": {
    "id": "feef6b72-1156-4058-8cdd-8200b1534be3",
    "package_id": "bd8cfa13-feba-425d-9d38-c6077dfb9cef",
    "resource_id": "37b54bf2-3fc1-4a40-b736-33744bb9aa1b",
    "activity_id": "dcd48169-4b8c-47c2-8f0b-7c11ca9221f6",
    "name": "2.3",
    "notes": "New notes with patch update",
    "creator_user_id": "8c0d7f45-1bf0-4e59-8e13-f7d6c5575822",
    "created": "2022-11-07 10:27:59.085900"
  }
}
```