### PR TITLE
Fix/metadata

### DIFF
--- a/ckanext/versions/templates/package/resource_version.html
+++ b/ckanext/versions/templates/package/resource_version.html
@@ -1,5 +1,25 @@
 {% extends "package/resource_read.html" %}
 
+
+{% block resource_actions_inner %}
+<li>
+  <div class="btn-group">
+  <a class="btn btn-primary resource-url-analytics" href="{{ res.url }}">
+    {% if res.resource_type in ('listing', 'service') %}
+      <i class="fa fa-eye"></i> {{ _('View') }}
+    {% elif  res.resource_type == 'api' %}
+      <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+    {% elif not res.has_views and not res.url_type == 'upload' %}
+      <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+    {% else %}
+      <i class="fa fa-arrow-circle-down"></i> {{ _('Download') }}
+    {% endif %}
+  </a>
+  {% block download_resource_button %}{% endblock download_resource_button %}
+  </div>
+</li>
+{% endblock %}
+
 {% block action_manage %}
 {% endblock action_manage %}
 
@@ -19,7 +39,6 @@
 {% endblock %}
 
 {% block data_preview %}
-
 {% endblock %}
 
 

--- a/ckanext/versions/templates/package/snippets/version_info.html
+++ b/ckanext/versions/templates/package/snippets/version_info.html
@@ -1,33 +1,35 @@
 {% set versions = h.get_package_version_list(pkg.id) %}
 {% if versions|length > 0 %}
 
-<h3>Versions</h3>
+<section class="version-info">
+    <h3>Versions</h3>
 
-<table class="table table-striped table-bordered table-condensed">
-    <thead>
-        <tr>
-            <th scope="col">Version</th>
-            <th scope="col">Notes</th>
-            <th scope="col">Published</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for version in h.get_package_version_list(pkg.id) %}
-        <tr>
-            <td>
-                {% if (loop.first) %}
-                    {{ version.name }} <span class="badge bg-success pull-right">Latest</span>
-                {% else %}
-                    <a href="{{ url_for('dataset_version.view_dataset', id=pkg.id,  version_id=version.id) }}">
-                        {{ version.name }} 
-                    </a>
-                {% endif %}
-            </td>
-            <td>{{ version.notes or "" }}</td>
-            <td>{{ version.created }}</td>
-        </tr>
-        {% endfor %}
+    <table class="table table-striped table-bordered table-condensed">
+        <thead>
+            <tr>
+                <th scope="col">Version</th>
+                <th scope="col">Notes</th>
+                <th scope="col">Published</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for version in h.get_package_version_list(pkg.id) %}
+            <tr>
+                <td>
+                    {% if (loop.first) %}
+                        {{ version.name }} <span class="badge bg-success pull-right">Latest</span>
+                    {% else %}
+                        <a href="{{ url_for('dataset_version.view_dataset', id=pkg.id,  version_id=version.id) }}">
+                            {{ version.name }} 
+                        </a>
+                    {% endif %}
+                </td>
+                <td>{{ version.notes or "" }}</td>
+                <td>{{ version.created }}</td>
+            </tr>
+            {% endfor %}
 
-    </tbody>
-</table>
+        </tbody>
+    </table>
+</section>
 {% endif %}

--- a/ckanext/versions/templates/package/version.html
+++ b/ckanext/versions/templates/package/version.html
@@ -11,7 +11,6 @@
       {% endtrans %}
     </div>
   {% endblock %}
-
   {{ super() }}
 {% endblock package_description %}
 
@@ -20,4 +19,14 @@
 {% endblock %}
 
 {% block content_action %}
+{% endblock %}
+
+{% block package_additional_info %}
+  {% if h.scheming_plugin_enabled() %}
+    {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%}
+    {% snippet "scheming/package/snippets/additional_info.html",
+    pkg_dict=pkg, dataset_type=dataset_type, schema=schema %}
+  {% else %}
+    {{ block.super }} {# Use block.super to call the parent block in Jinja2 #}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
This pull request introduces enhancements to the CKAN templates, focusing on improving resource actions, adding version information styling, and including additional dataset information when the scheming plugin is enabled. Below are the key changes grouped by theme:

### Enhancements to Resource Actions:
* Added a new `resource_actions_inner` block in `resource_version.html` to provide context-specific action buttons (e.g., "View," "API Endpoint," "Download") based on the resource type. This improves user interaction with resources.

### Styling and Structure Improvements:
* Wrapped the version information in a `<section>` with the class `version-info` in `version_info.html` for better semantic structure and styling. [[1]](diffhunk://#diff-302c35077ff5fd6ef99ba614c4e57cbea4d8431484c02bddc1245debad6a9e51R4) [[2]](diffhunk://#diff-302c35077ff5fd6ef99ba614c4e57cbea4d8431484c02bddc1245debad6a9e51R34)

### Additional Dataset Information:
* Introduced a `package_additional_info` block in `version.html` to display extra dataset information when the scheming plugin is enabled. It uses a snippet to render the additional details or falls back to the parent block if the plugin is not active.

### Minor Cleanup:
* Removed unnecessary whitespace in `resource_version.html` and `version.html` for cleaner templates. [[1]](diffhunk://#diff-2c0134f10b2c976eda1a5e00a3a10ae44dd1309dc7b02f3e2bfe9a2a0fd96feaL22) [[2]](diffhunk://#diff-38bb3ed3ed1bed35459e8ea9fac1452439d988e53a4130cd49d7f0dce3bd51e2L14)