### PR TITLE
fix: helper function not found bug fix

### DIFF
--- a/ckanext/versions/helpers.py
+++ b/ckanext/versions/helpers.py
@@ -20,3 +20,11 @@ def get_package_version_list(package_id):
     return version_list
 
 
+def scheming_plugin_enabled():
+    """
+    Check if the scheming plugin is enabled.
+    :return: True if the scheming plugin is enabled, False otherwise
+    """
+    if 'scheming_datasets' in tk.config.get('ckan.plugins', ' '):
+        return True
+    return False

--- a/ckanext/versions/plugin.py
+++ b/ckanext/versions/plugin.py
@@ -60,6 +60,7 @@ class VersionsPlugin(plugins.SingletonPlugin):
     def get_helpers(self):
         return {
             "get_package_version_list": helpers.get_package_version_list,
+            "scheming_plugin_enabled": helpers.scheming_plugin_enabled,
         }
 
     # IBlueprints


### PR DESCRIPTION
This pull request introduces a new helper function to check if the "scheming" plugin is enabled and integrates it into the plugin's helper registry. These changes improve the plugin's extensibility by exposing the new functionality for use in other parts of the codebase.

### New helper function:

* Added the `scheming_plugin_enabled` function in `ckanext/versions/helpers.py`. This function checks whether the "scheming_datasets" plugin is enabled in the CKAN configuration and returns a boolean value.

### Integration into the plugin:

* Registered the `scheming_plugin_enabled` helper in the `get_helpers` method of `ckanext/versions/plugin.py`, making it accessible as a plugin helper.